### PR TITLE
feat: implement anti-snipe protection for IP tokens

### DIFF
--- a/src/IPAntiSnipeToken.sol
+++ b/src/IPAntiSnipeToken.sol
@@ -1,60 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
-import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
-
-import {PoolAddress} from "./lib/storyhunt/PoolAddress.sol";
-import {IStoryHuntV3MintCallback} from "./interfaces/storyhunt/IStoryHuntV3MintCallback.sol";
-
-import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
-import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
-
-import {PositionKey} from "@uniswap/v3-periphery/contracts/libraries/PositionKey.sol";
-import {LiquidityAmounts} from "@uniswap/v3-periphery/contracts/libraries/LiquidityAmounts.sol";
-
-import {IIPToken} from "./interfaces/IIPToken.sol";
-import {IIPWorld} from "./interfaces/IIPWorld.sol";
-import {IWETH9} from "./interfaces/IWETH9.sol";
+import {IPToken} from "./IPToken.sol";
+import {IAntiSnipeToken} from "./interfaces/IAntiSnipeToken.sol";
 import {Errors} from "./lib/Errors.sol";
 
 /// @title IPAntiSnipeToken
 /// @notice ERC20 token with automated bid wall for price support, permit functionality, and anti-snipe protection
-/// @dev Deployed by IPWorld, features burnable tokens, bid wall mechanism using fixed WETH amount, and transfer limits during anti-snipe period
-contract IPAntiSnipeToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3MintCallback {
-    using TickMath for int24;
-
-    /// @notice Total supply allocation for new token deploys (1 billion tokens)
-    uint256 internal constant TOTAL_SUPPLY = 1_000_000_000 * 1e18;
-
-    /// @notice Fee tier for Uniswap V3 pool (0.3% fee)
-    uint24 internal constant V3_FEE = 3000;
-
-    /// @notice Tick spacing for bid wall positions (60 for 0.3% fee tier)
-    int24 internal constant TICK_SPACING = 60;
-
-    /// @notice Maximum valid tick for bid wall positioning (adjusted for tick spacing)
-    int24 internal constant MAX_TICK = TickMath.MAX_TICK - (TickMath.MAX_TICK % TICK_SPACING);
-
+/// @dev Extends IPToken with transfer limits during anti-snipe period
+contract IPAntiSnipeToken is IPToken, IAntiSnipeToken {
     /// @notice Maximum sniper amount during anti-snipe period
-    uint256 internal constant MAX_SNIPER_AMOUNT = 300_000_000 * 1e18;
-
-    /// @notice Address of the IP World contract that deployed this token
-    address internal immutable _ipWorld;
-
-    /// @notice Address of Wrapped Ether for the trading pair
-    address internal immutable _weth;
-
-    /// @notice Address of the token creator
-    address public immutable tokenCreator;
-
-    /// @notice Address of the liquidity pool
-    address public immutable liquidityPool;
-
-    /// @notice Amount of bid wall
-    uint256 public immutable bidWallAmount;
+    uint256 public constant MAX_SNIPER_AMOUNT = 200_000_000 * 1e18;
 
     /// @notice Duration of anti-snipe period in seconds (0 = no limit)
     uint256 public immutable antiSnipeDuration;
@@ -62,11 +18,8 @@ contract IPAntiSnipeToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStory
     /// @notice Token creation timestamp
     uint256 private immutable _creationTimestamp;
 
-    /// @notice Tick range for the bid wall
-    int24 public bidWallTickLower;
-
-    /// @notice Initializes the IP token contract with fixed supply and bid wall configuration
-    /// @dev Mints total supply to msg.sender (IPWorld), computes pool address deterministically
+    /// @notice Initializes the IP anti-snipe token contract with transfer limits
+    /// @dev Extends IPToken constructor with anti-snipe duration
     /// @param tokenCreator_ Address of the original token creator/developer
     /// @param v3Deployer_ Address of the Uniswap V3 deployer for pool address computation
     /// @param weth_ Address of the Wrapped Ether contract for the trading pair
@@ -82,147 +35,9 @@ contract IPAntiSnipeToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStory
         uint256 antiSnipeDuration_,
         string memory name_,
         string memory symbol_
-    ) ERC20(name_, symbol_) ERC20Permit(name_) {
-        tokenCreator = tokenCreator_;
-        _mint(msg.sender, TOTAL_SUPPLY);
-        _ipWorld = msg.sender;
-        _weth = weth_;
-        liquidityPool = PoolAddress.computeAddress(v3Deployer_, PoolAddress.getPoolKey(address(this), weth_, V3_FEE));
-        bidWallTickLower = MAX_TICK;
-        bidWallAmount = bidWallAmount_;
+    ) IPToken(tokenCreator_, v3Deployer_, weth_, bidWallAmount_, name_, symbol_) {
         antiSnipeDuration = antiSnipeDuration_;
         _creationTimestamp = block.timestamp;
-    }
-
-    function repositionBidWall() external {
-        (, int24 currentTick,,,,,) = IUniswapV3Pool(liquidityPool).slot0();
-        bool nativeIsZero = _weth < address(this);
-
-        int24 newTickLower;
-        int24 newTickUpper;
-
-        (uint256 wethCollected, uint256 tokensCollected) =
-            _collectLiquidity(IUniswapV3Pool(liquidityPool), bidWallTickLower, nativeIsZero);
-        uint256 burnAmount = balanceOf(address(this));
-        if (burnAmount > 0) {
-            _burn(address(this), burnAmount);
-        }
-
-        if (nativeIsZero) {
-            int24 baseTick = currentTick + 1;
-            newTickLower = _validTick(baseTick, false);
-            newTickUpper = newTickLower + TICK_SPACING;
-            if (newTickUpper > MAX_TICK) {
-                return;
-            }
-        } else {
-            int24 baseTick = currentTick - 1;
-            newTickUpper = _validTick(baseTick, true);
-            newTickLower = newTickUpper - TICK_SPACING;
-            if (newTickLower < -MAX_TICK) {
-                return;
-            }
-        }
-        uint256 wethForLiquidity = IERC20(_weth).balanceOf(address(this));
-        if (wethForLiquidity > bidWallAmount) {
-            wethForLiquidity = bidWallAmount;
-        }
-        uint128 newLiquidity =
-            _addLiquidity(IUniswapV3Pool(liquidityPool), wethForLiquidity, newTickLower, nativeIsZero);
-
-        bidWallTickLower = newTickLower;
-
-        // Emit bid wall repositioned event
-        emit BidWallRepositioned(
-            newTickLower, newTickUpper, wethCollected, tokensCollected, burnAmount, wethForLiquidity, newLiquidity
-        );
-    }
-
-    /// @notice Adds WETH liquidity to create a one-sided bid wall at specified tick range
-    /// @param pool Uniswap V3 pool to add liquidity to
-    /// @param wethForLiquidity Amount of WETH to use for liquidity provision
-    /// @param tickLower Lower tick boundary for the bid wall position
-    /// @param nativeIsZero Whether WETH is token0 in the pool
-    function _addLiquidity(IUniswapV3Pool pool, uint256 wethForLiquidity, int24 tickLower, bool nativeIsZero)
-        internal
-        returns (uint128 liquidity)
-    {
-        if (wethForLiquidity == 0) return 0;
-        int24 tickUpper = tickLower + TICK_SPACING;
-        uint160 lowerSqrtPriceX96 = tickLower.getSqrtRatioAtTick();
-        uint160 upperSqrtPriceX96 = tickUpper.getSqrtRatioAtTick();
-
-        if (nativeIsZero) {
-            liquidity = LiquidityAmounts.getLiquidityForAmount0(lowerSqrtPriceX96, upperSqrtPriceX96, wethForLiquidity);
-        } else {
-            liquidity = LiquidityAmounts.getLiquidityForAmount1(lowerSqrtPriceX96, upperSqrtPriceX96, wethForLiquidity);
-        }
-        if (liquidity == 0) return 0;
-
-        pool.mint(address(this), tickLower, tickUpper, liquidity, "");
-        return liquidity;
-    }
-
-    /// @notice Collects all liquidity and fees from the bid wall position
-    /// @param pool Uniswap V3 pool to collect from
-    /// @param tickLower Lower tick boundary of the bid wall position
-    /// @param nativeIsZero Whether WETH is token0 in the pool
-    /// @return wethAmount Amount of WETH collected from the position
-    /// @return tokenAmount Amount of IP tokens collected from the position
-    function _collectLiquidity(IUniswapV3Pool pool, int24 tickLower, bool nativeIsZero)
-        internal
-        returns (uint256 wethAmount, uint256 tokenAmount)
-    {
-        int24 tickUpper;
-        if (nativeIsZero) {
-            tickUpper = tickLower + TICK_SPACING;
-        } else {
-            tickUpper = -tickLower;
-            tickLower = -tickLower - TICK_SPACING;
-        }
-
-        bytes32 positionKey = PositionKey.compute(address(this), tickLower, tickUpper);
-        (uint128 burnAmount,,,,) = pool.positions(positionKey);
-        if (burnAmount == 0) return (0, 0);
-        pool.burn(tickLower, tickUpper, burnAmount);
-        (wethAmount, tokenAmount) =
-            pool.collect(address(this), tickLower, tickUpper, type(uint128).max, type(uint128).max);
-    }
-
-    /// @notice Normalizes a tick value to conform to Uniswap V3 tick spacing requirements
-    /// @dev This function handles several critical cases:
-    ///      1. Clamps ticks to valid range [-MAX_TICK, MAX_TICK]
-    ///      2. Rounds ticks to nearest valid tick (divisible by TICK_SPACING)
-    ///      3. For negative ticks, adjusts rounding behavior due to integer division truncation
-    ///      4. Ensures final result doesn't exceed boundaries when rounding up
-    /// @param tick Raw tick value that may not conform to tick spacing
-    /// @param _roundDown True to round down to nearest valid tick, false to round up
-    /// @return tick_ Valid tick that conforms to TICK_SPACING and is within valid range
-    function _validTick(int24 tick, bool _roundDown) internal pure returns (int24 tick_) {
-        // If we have a malformed tick, then we need to bring it back within range
-        if (tick < -MAX_TICK) tick = -MAX_TICK;
-        else if (tick > MAX_TICK) tick = MAX_TICK;
-
-        // If the tick is already valid, exit early
-        if (tick % TICK_SPACING == 0) {
-            return tick;
-        }
-
-        tick = tick / TICK_SPACING * TICK_SPACING;
-        if (tick < 0) {
-            tick -= TICK_SPACING;
-        }
-
-        // If we are rounding up, then we can just add a `TICK_SPACING` to the lower tick
-        if (!_roundDown) {
-            int24 result = tick + TICK_SPACING;
-            // Ensure the result doesn't exceed MAX_TICK
-            if (result > MAX_TICK) {
-                result = MAX_TICK;
-            }
-            return result;
-        }
-        return tick;
     }
 
     /// @notice Override transfer to implement anti-snipe protection
@@ -262,20 +77,5 @@ contract IPAntiSnipeToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStory
 
         _transfer(from, to, amount);
         return true;
-    }
-
-    /// @notice Transfers tokens to LP pool post-deployment via v3 mint callback
-    /// @param amount0Owed Amount of token0 required for liquidity transfer
-    /// @param amount1Owed Amount of token1 required for liquidity transfer
-    function storyHuntV3MintCallback(uint256 amount0Owed, uint256 amount1Owed, bytes calldata) external {
-        if (msg.sender != liquidityPool) {
-            revert Errors.IPToken_OnlyLiquidityPool();
-        }
-
-        if (amount1Owed > 0) {
-            IERC20(_weth).transfer(msg.sender, amount1Owed);
-        } else if (amount0Owed > 0) {
-            IERC20(_weth).transfer(msg.sender, amount0Owed);
-        }
     }
 }

--- a/src/IPToken.sol
+++ b/src/IPToken.sol
@@ -38,6 +38,9 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
     /// @notice Maximum valid tick for bid wall positioning (adjusted for tick spacing)
     int24 internal constant MAX_TICK = TickMath.MAX_TICK - (TickMath.MAX_TICK % TICK_SPACING);
 
+    /// @notice Maximum sniper amount during anti-snipe period
+    uint256 internal constant MAX_SNIPER_AMOUNT = 300_000_000 * 1e18;
+
     /// @notice Address of the IP World contract that deployed this token
     address internal immutable _ipWorld;
 
@@ -53,6 +56,12 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
     /// @notice Amount of bid wall
     uint256 public immutable bidWallAmount;
 
+    /// @notice Duration of anti-snipe period in seconds (0 = no limit)
+    uint256 public immutable antiSnipeDuration;
+
+    /// @notice Token creation timestamp
+    uint256 private immutable _creationTimestamp;
+
     /// @notice Tick range for the bid wall
     int24 public bidWallTickLower;
 
@@ -62,6 +71,7 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
     /// @param v3Deployer_ Address of the Uniswap V3 deployer for pool address computation
     /// @param weth_ Address of the Wrapped Ether contract for the trading pair
     /// @param bidWallAmount_ Fixed amount of ETH reserved for bid wall operations
+    /// @param antiSnipeDuration_ Duration of anti-snipe period in seconds (0 = no limit)
     /// @param name_ ERC20 token name
     /// @param symbol_ ERC20 token symbol
     constructor(
@@ -69,6 +79,7 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
         address v3Deployer_,
         address weth_,
         uint256 bidWallAmount_,
+        uint256 antiSnipeDuration_,
         string memory name_,
         string memory symbol_
     ) ERC20(name_, symbol_) ERC20Permit(name_) {
@@ -79,6 +90,8 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
         liquidityPool = PoolAddress.computeAddress(v3Deployer_, PoolAddress.getPoolKey(address(this), weth_, V3_FEE));
         bidWallTickLower = MAX_TICK;
         bidWallAmount = bidWallAmount_;
+        antiSnipeDuration = antiSnipeDuration_;
+        _creationTimestamp = block.timestamp;
     }
 
     function repositionBidWall() external {
@@ -210,6 +223,45 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
             return result;
         }
         return tick;
+    }
+
+    /// @notice Override transfer to implement anti-snipe protection
+    /// @dev Restricts transfers from liquidity pool during anti-snipe period
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        address owner = _msgSender();
+
+        // Check anti-snipe protection if enabled and transfer is from liquidity pool
+        if (antiSnipeDuration > 0 && owner == liquidityPool && block.timestamp < _creationTimestamp + antiSnipeDuration)
+        {
+            // During anti-snipe period, limit transfers from liquidity pool
+            // But allow token creator to buy without limit
+            if (to != tokenCreator && amount > MAX_SNIPER_AMOUNT) {
+                revert Errors.IPToken_ExceedsAntiSnipeLimit();
+            }
+        }
+
+        _transfer(owner, to, amount);
+        return true;
+    }
+
+    /// @notice Override transferFrom to implement anti-snipe protection
+    /// @dev Restricts transfers from liquidity pool during anti-snipe period
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        address spender = _msgSender();
+        _spendAllowance(from, spender, amount);
+
+        // Check anti-snipe protection if enabled and transfer is from liquidity pool
+        if (antiSnipeDuration > 0 && from == liquidityPool && block.timestamp < _creationTimestamp + antiSnipeDuration)
+        {
+            // During anti-snipe period, limit transfers from liquidity pool
+            // But allow token creator to buy without limit
+            if (to != tokenCreator && amount > MAX_SNIPER_AMOUNT) {
+                revert Errors.IPToken_ExceedsAntiSnipeLimit();
+            }
+        }
+
+        _transfer(from, to, amount);
+        return true;
     }
 
     /// @notice Transfers tokens to LP pool post-deployment via v3 mint callback

--- a/src/IPToken.sol
+++ b/src/IPToken.sol
@@ -38,6 +38,9 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
     /// @notice Maximum valid tick for bid wall positioning (adjusted for tick spacing)
     int24 internal constant MAX_TICK = TickMath.MAX_TICK - (TickMath.MAX_TICK % TICK_SPACING);
 
+    /// @notice Maximum sniper amount during anti-snipe period (2% of total supply)
+    uint256 public constant MAX_SNIPER_AMOUNT = 20_000_000 * 1e18;
+
     /// @notice Address of the IP World contract that deployed this token
     address internal immutable _ipWorld;
 
@@ -53,6 +56,12 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
     /// @notice Amount of bid wall
     uint256 public immutable bidWallAmount;
 
+    /// @notice Duration of anti-snipe period in seconds (0 = no limit)
+    uint256 public immutable antiSnipeDuration;
+
+    /// @notice Token creation timestamp
+    uint256 private immutable _creationTimestamp;
+
     /// @notice Tick range for the bid wall
     int24 public bidWallTickLower;
 
@@ -62,6 +71,7 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
     /// @param v3Deployer_ Address of the Uniswap V3 deployer for pool address computation
     /// @param weth_ Address of the Wrapped Ether contract for the trading pair
     /// @param bidWallAmount_ Fixed amount of ETH reserved for bid wall operations
+    /// @param antiSnipeDuration_ Duration of anti-snipe period in seconds (0 = no limit)
     /// @param name_ ERC20 token name
     /// @param symbol_ ERC20 token symbol
     constructor(
@@ -69,6 +79,7 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
         address v3Deployer_,
         address weth_,
         uint256 bidWallAmount_,
+        uint256 antiSnipeDuration_,
         string memory name_,
         string memory symbol_
     ) ERC20(name_, symbol_) ERC20Permit(name_) {
@@ -79,6 +90,8 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
         liquidityPool = PoolAddress.computeAddress(v3Deployer_, PoolAddress.getPoolKey(address(this), weth_, V3_FEE));
         bidWallTickLower = MAX_TICK;
         bidWallAmount = bidWallAmount_;
+        antiSnipeDuration = antiSnipeDuration_;
+        _creationTimestamp = block.timestamp;
     }
 
     function repositionBidWall() external {
@@ -227,9 +240,42 @@ contract IPToken is IIPToken, ERC20, ERC20Burnable, ERC20Permit, IStoryHuntV3Min
         }
     }
 
-    /// @notice Returns the anti-snipe duration (always 0 for regular IPToken)
-    /// @return Duration of anti-snipe protection in seconds
-    function antiSnipeDuration() external pure returns (uint256) {
-        return 0;
+    /// @notice Override transfer to implement anti-snipe protection
+    /// @dev Restricts transfers from liquidity pool during anti-snipe period
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        address owner = _msgSender();
+
+        // Check anti-snipe protection if enabled and transfer is from liquidity pool
+        if (antiSnipeDuration > 0 && owner == liquidityPool && block.timestamp < _creationTimestamp + antiSnipeDuration)
+        {
+            // During anti-snipe period, limit transfers from liquidity pool
+            // But allow token creator to buy without limit
+            if (to != tokenCreator && amount > MAX_SNIPER_AMOUNT) {
+                revert Errors.IPToken_ExceedsAntiSnipeLimit();
+            }
+        }
+
+        _transfer(owner, to, amount);
+        return true;
+    }
+
+    /// @notice Override transferFrom to implement anti-snipe protection
+    /// @dev Restricts transfers from liquidity pool during anti-snipe period
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        address spender = _msgSender();
+        _spendAllowance(from, spender, amount);
+
+        // Check anti-snipe protection if enabled and transfer is from liquidity pool
+        if (antiSnipeDuration > 0 && from == liquidityPool && block.timestamp < _creationTimestamp + antiSnipeDuration)
+        {
+            // During anti-snipe period, limit transfers from liquidity pool
+            // But allow token creator to buy without limit
+            if (to != tokenCreator && amount > MAX_SNIPER_AMOUNT) {
+                revert Errors.IPToken_ExceedsAntiSnipeLimit();
+            }
+        }
+
+        _transfer(from, to, amount);
+        return true;
     }
 }

--- a/src/IPTokenDeployer.sol
+++ b/src/IPTokenDeployer.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.26;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IIPTokenDeployer} from "./interfaces/IIPTokenDeployer.sol";
 import {IPToken} from "./IPToken.sol";
+import {IPAntiSnipeToken} from "./IPAntiSnipeToken.sol";
 import {Errors} from "./lib/Errors.sol";
 
 /// @title IPTokenDeployer
@@ -38,10 +39,17 @@ contract IPTokenDeployer is IIPTokenDeployer {
         uint256 bidWallAmount,
         uint256 antiSnipeDuration,
         string calldata name,
-        string calldata symbol
+        string calldata symbol,
+        bool useAntiSnipe
     ) external onlyIPWorld returns (address token) {
-        // Deploy the token - it will mint all tokens to this contract
-        token = address(new IPToken(tokenCreator, v3Deployer, weth, bidWallAmount, antiSnipeDuration, name, symbol));
+        // Deploy the appropriate token type based on useAntiSnipe flag
+        if (useAntiSnipe) {
+            token = address(
+                new IPAntiSnipeToken(tokenCreator, v3Deployer, weth, bidWallAmount, antiSnipeDuration, name, symbol)
+            );
+        } else {
+            token = address(new IPToken(tokenCreator, v3Deployer, weth, bidWallAmount, name, symbol));
+        }
 
         // Transfer all tokens to IPWorld
         uint256 balance = IERC20(token).balanceOf(address(this));

--- a/src/IPTokenDeployer.sol
+++ b/src/IPTokenDeployer.sol
@@ -36,11 +36,12 @@ contract IPTokenDeployer is IIPTokenDeployer {
         address v3Deployer,
         address weth,
         uint256 bidWallAmount,
+        uint256 antiSnipeDuration,
         string calldata name,
         string calldata symbol
     ) external onlyIPWorld returns (address token) {
         // Deploy the token - it will mint all tokens to this contract
-        token = address(new IPToken(tokenCreator, v3Deployer, weth, bidWallAmount, name, symbol));
+        token = address(new IPToken(tokenCreator, v3Deployer, weth, bidWallAmount, antiSnipeDuration, name, symbol));
 
         // Transfer all tokens to IPWorld
         uint256 balance = IERC20(token).balanceOf(address(this));

--- a/src/IPTokenDeployer.sol
+++ b/src/IPTokenDeployer.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.26;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IIPTokenDeployer} from "./interfaces/IIPTokenDeployer.sol";
 import {IPToken} from "./IPToken.sol";
-import {IPAntiSnipeToken} from "./IPAntiSnipeToken.sol";
 import {Errors} from "./lib/Errors.sol";
 
 /// @title IPTokenDeployer
@@ -39,17 +38,10 @@ contract IPTokenDeployer is IIPTokenDeployer {
         uint256 bidWallAmount,
         uint256 antiSnipeDuration,
         string calldata name,
-        string calldata symbol,
-        bool useAntiSnipe
+        string calldata symbol
     ) external onlyIPWorld returns (address token) {
-        // Deploy the appropriate token type based on useAntiSnipe flag
-        if (useAntiSnipe) {
-            token = address(
-                new IPAntiSnipeToken(tokenCreator, v3Deployer, weth, bidWallAmount, antiSnipeDuration, name, symbol)
-            );
-        } else {
-            token = address(new IPToken(tokenCreator, v3Deployer, weth, bidWallAmount, name, symbol));
-        }
+        // Deploy IPToken with anti-snipe duration (0 = disabled, >0 = enabled)
+        token = address(new IPToken(tokenCreator, v3Deployer, weth, bidWallAmount, antiSnipeDuration, name, symbol));
 
         // Transfer all tokens to IPWorld
         uint256 balance = IERC20(token).balanceOf(address(this));

--- a/src/IPWorld.sol
+++ b/src/IPWorld.sol
@@ -225,7 +225,8 @@ contract IPWorld is IIPWorld, IStoryHuntV3MintCallback, Ownable2StepUpgradeable,
         string calldata symbol,
         address ipaId,
         int24[] calldata startTickList,
-        uint256[] calldata allocationList
+        uint256[] calldata allocationList,
+        bool antiSnipe
     ) external onlyOperator returns (address pool, address token) {
         if (tokenCreator == address(0)) {
             revert Errors.IPWorld_InvalidAddress();
@@ -235,8 +236,9 @@ contract IPWorld is IIPWorld, IStoryHuntV3MintCallback, Ownable2StepUpgradeable,
             revert Errors.IPWorld_InvalidTick();
         }
 
+        uint256 antiSnipeDuration = antiSnipe ? ANTI_SNIPE_DURATION : 0;
         token = _tokenDeployer.deployToken(
-            tokenCreator, _v3Deployer, _weth, bidWallAmount, ANTI_SNIPE_DURATION, name, symbol
+            tokenCreator, _v3Deployer, _weth, bidWallAmount, antiSnipeDuration, name, symbol, antiSnipe
         );
         pool = _v3Factory.getPool(token, _weth, V3_FEE);
         if (pool == address(0)) {

--- a/src/IPWorld.sol
+++ b/src/IPWorld.sol
@@ -34,6 +34,9 @@ contract IPWorld is IIPWorld, IStoryHuntV3MintCallback, Ownable2StepUpgradeable,
 
     uint24 public constant V3_FEE = 3000;
 
+    /// @notice Anti-snipe duration in seconds
+    uint256 public constant ANTI_SNIPE_DURATION = 600;
+
     /// @notice Tick spacing for LP pools (60 is used for a 0.3% fee tier)
     int24 private constant TICK_SPACING = 60;
 
@@ -232,7 +235,9 @@ contract IPWorld is IIPWorld, IStoryHuntV3MintCallback, Ownable2StepUpgradeable,
             revert Errors.IPWorld_InvalidTick();
         }
 
-        token = _tokenDeployer.deployToken(tokenCreator, _v3Deployer, _weth, bidWallAmount, name, symbol);
+        token = _tokenDeployer.deployToken(
+            tokenCreator, _v3Deployer, _weth, bidWallAmount, ANTI_SNIPE_DURATION, name, symbol
+        );
         pool = _v3Factory.getPool(token, _weth, V3_FEE);
         if (pool == address(0)) {
             pool = _v3Factory.createPool(token, _weth, V3_FEE);

--- a/src/interfaces/IIPToken.sol
+++ b/src/interfaces/IIPToken.sol
@@ -41,6 +41,10 @@ interface IIPToken {
     /// @return Current lower tick position of the bid wall
     function bidWallTickLower() external view returns (int24);
 
+    /// @notice Duration of anti-snipe period in seconds (0 = no limit)
+    /// @return Duration of anti-snipe protection in seconds
+    function antiSnipeDuration() external view returns (uint256);
+
     /// @notice Repositions the bid wall based on current market conditions
     /// @dev This function collects existing liquidity, burns tokens, and creates new liquidity at appropriate tick range
     function repositionBidWall() external;

--- a/src/interfaces/IIPToken.sol
+++ b/src/interfaces/IIPToken.sol
@@ -41,10 +41,6 @@ interface IIPToken {
     /// @return Current lower tick position of the bid wall
     function bidWallTickLower() external view returns (int24);
 
-    /// @notice Duration of anti-snipe period in seconds (0 = no limit)
-    /// @return Duration of anti-snipe protection in seconds
-    function antiSnipeDuration() external view returns (uint256);
-
     /// @notice Repositions the bid wall based on current market conditions
     /// @dev This function collects existing liquidity, burns tokens, and creates new liquidity at appropriate tick range
     function repositionBidWall() external;

--- a/src/interfaces/IIPTokenDeployer.sol
+++ b/src/interfaces/IIPTokenDeployer.sol
@@ -20,6 +20,7 @@ interface IIPTokenDeployer {
     /// @param v3Deployer Address of the Uniswap V3 deployer for pool address computation
     /// @param weth Address of the Wrapped Ether contract for the trading pair
     /// @param bidWallAmount Fixed amount of ETH reserved for bid wall operations
+    /// @param antiSnipeDuration Duration of anti-snipe period in seconds (0 = no limit)
     /// @param name ERC20 token name
     /// @param symbol ERC20 token symbol
     /// @return token Address of the deployed IP token
@@ -28,6 +29,7 @@ interface IIPTokenDeployer {
         address v3Deployer,
         address weth,
         uint256 bidWallAmount,
+        uint256 antiSnipeDuration,
         string calldata name,
         string calldata symbol
     ) external returns (address token);

--- a/src/interfaces/IIPTokenDeployer.sol
+++ b/src/interfaces/IIPTokenDeployer.sol
@@ -31,7 +31,8 @@ interface IIPTokenDeployer {
         uint256 bidWallAmount,
         uint256 antiSnipeDuration,
         string calldata name,
-        string calldata symbol
+        string calldata symbol,
+        bool useAntiSnipe
     ) external returns (address token);
 
     /// @notice Returns the address of IPWorld contract

--- a/src/interfaces/IIPTokenDeployer.sol
+++ b/src/interfaces/IIPTokenDeployer.sol
@@ -31,8 +31,7 @@ interface IIPTokenDeployer {
         uint256 bidWallAmount,
         uint256 antiSnipeDuration,
         string calldata name,
-        string calldata symbol,
-        bool useAntiSnipe
+        string calldata symbol
     ) external returns (address token);
 
     /// @notice Returns the address of IPWorld contract

--- a/src/interfaces/IIPWorld.sol
+++ b/src/interfaces/IIPWorld.sol
@@ -118,6 +118,10 @@ interface IIPWorld {
     /// @return Fixed amount of ETH used for each token's bid wall
     function bidWallAmount() external view returns (uint256);
 
+    /// @notice Duration of anti-snipe protection in seconds
+    /// @return Duration of anti-snipe period for newly created tokens
+    function ANTI_SNIPE_DURATION() external view returns (uint256);
+
     /// @notice Checks if an address is an operator
     /// @param operator Address to check
     /// @return True if the address is an operator, false otherwise

--- a/src/interfaces/IIPWorld.sol
+++ b/src/interfaces/IIPWorld.sol
@@ -189,7 +189,8 @@ interface IIPWorld {
         string calldata symbol,
         address ipaId,
         int24[] calldata startTickList,
-        uint256[] calldata allocationList
+        uint256[] calldata allocationList,
+        bool antiSnipe
     ) external returns (address pool, address token);
 
     /// @notice Harvests fees from active liquidity positions and distributes to stakeholders

--- a/src/lib/Errors.sol
+++ b/src/lib/Errors.sol
@@ -10,6 +10,9 @@ library Errors {
     /// @notice Only liquidity pool can call this function
     error IPToken_OnlyLiquidityPool();
 
+    /// @notice Transfer amount exceeds anti-snipe limit
+    error IPToken_ExceedsAntiSnipeLimit();
+
     ////////////////////////////////////////////////////////////////////////////
     //                            IPWorld                                    //
     ////////////////////////////////////////////////////////////////////////////

--- a/test/integration/Harvest.t.sol
+++ b/test/integration/Harvest.t.sol
@@ -24,7 +24,7 @@ contract HarvestTest is BaseTest {
     function test_Harvest_Unverified() public {
         vm.prank(address(operator));
         (address pool, address tokenAddr) =
-            ipWorld.createIpToken(alice, "chill", "CHILL", address(0), startTickList, allocationList);
+            ipWorld.createIpToken(alice, "chill", "CHILL", address(0), startTickList, allocationList, false);
         swap(IUniswapV3Pool(pool), 1 ether);
 
         IERC20 token = IERC20(tokenAddr);
@@ -85,7 +85,7 @@ contract HarvestTest is BaseTest {
         ipWorld.claimIp(ipaId, alice);
         vm.prank(address(operator));
         (address pool, address tokenAddr) =
-            ipWorld.createIpToken(alice, "chill", "CHILL", ipaId, startTickList, allocationList);
+            ipWorld.createIpToken(alice, "chill", "CHILL", ipaId, startTickList, allocationList, false);
         swap(IUniswapV3Pool(pool), 1 ether);
 
         IERC20 token = IERC20(tokenAddr);

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -52,11 +52,12 @@ contract IntegrationTest is BaseTest {
             keccak256(
                 abi.encode(
                     keccak256(
-                        "CREATE(address creator,int24[] startTick,uint256[] allocationList,uint256 nonce,uint256 deadline)"
+                        "CREATE(address creator,int24[] startTick,uint256[] allocationList,bool antiSnipe,uint256 nonce,uint256 deadline)"
                     ),
                     alice,
                     keccak256(abi.encodePacked(startTickList)),
                     keccak256(abi.encodePacked(allocationList)),
+                    false,
                     operator.nonces(alice),
                     block.timestamp + 1000
                 )
@@ -67,7 +68,7 @@ contract IntegrationTest is BaseTest {
 
         vm.prank(alice);
         (, address tokenAddr) = operator.createIpTokenWithSig{value: 1 ether}(
-            "chill", "CHILL", address(0), startTickList, allocationList, block.timestamp + 1000, sig
+            "chill", "CHILL", address(0), startTickList, allocationList, false, block.timestamp + 1000, sig
         );
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
@@ -147,7 +148,8 @@ contract IntegrationTest is BaseTest {
         allocList[1] = 220000;
 
         vm.prank(address(operator));
-        (, address tokenAddr) = ipWorld.createIpToken(alice, "MEME", "Meme Token", address(0), tickList, allocList);
+        (, address tokenAddr) =
+            ipWorld.createIpToken(alice, "MEME", "Meme Token", address(0), tickList, allocList, false);
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
 
@@ -403,7 +405,7 @@ contract IntegrationTest is BaseTest {
         // Create IP token with specified parameters
         vm.prank(address(operator));
         (, address tokenAddr) =
-            ipWorld.createIpToken(alice, "MEME", "Meme Token", address(0), testStartTicks, testAllocations);
+            ipWorld.createIpToken(alice, "MEME", "Meme Token", address(0), testStartTicks, testAllocations, false);
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
 
@@ -730,7 +732,7 @@ contract IntegrationTest is BaseTest {
         // Create IP token
         vm.prank(address(operator));
         (, address tokenAddr) =
-            ipWorld.createIpToken(alice, "MEME", "Meme Token", address(0), testStartTicks, testAllocations);
+            ipWorld.createIpToken(alice, "MEME", "Meme Token", address(0), testStartTicks, testAllocations, false);
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
 
@@ -1012,7 +1014,7 @@ contract IntegrationTest is BaseTest {
         // Create and test token
         vm.prank(address(operator));
         (, address tokenAddr) =
-            ipWorld.createIpToken(alice, "MEME", "Test Token", address(0), testStartTicks, testAllocations);
+            ipWorld.createIpToken(alice, "MEME", "Test Token", address(0), testStartTicks, testAllocations, false);
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
 
@@ -1087,7 +1089,7 @@ contract IntegrationTest is BaseTest {
         // Create token
         vm.prank(address(operator));
         (, address tokenAddr) =
-            ipWorld.createIpToken(alice, "MEME", "Test Token", address(0), testStartTicks, testAllocations);
+            ipWorld.createIpToken(alice, "MEME", "Test Token", address(0), testStartTicks, testAllocations, false);
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
 

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -151,6 +151,9 @@ contract IntegrationTest is BaseTest {
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
 
+        // Skip anti-snipe period (600 seconds + buffer)
+        vm.warp(block.timestamp + 3600); // 1 hour forward
+
         // Display market cap before Alice's purchase
         console2.log("\n--- Market Cap Before Alice's Purchase ---");
         getMarketCap(token);
@@ -404,6 +407,9 @@ contract IntegrationTest is BaseTest {
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
 
+        // Skip anti-snipe period (600 seconds + buffer)
+        vm.warp(block.timestamp + 3600); // 1 hour forward
+
         // Initial state
         console2.log("\n--- Initial State ---");
         console2.log("Total Supply:", token.totalSupply() / 1e18, "tokens");
@@ -641,7 +647,7 @@ contract IntegrationTest is BaseTest {
         return string(bstr);
     }
 
-    function skip_test_BacktestOptimization() public {
+    function test_BacktestOptimization() public {
         vm.deal(alice, 1000000000 ether);
 
         console2.log("\n===== PARAMETER OPTIMIZATION BACKTEST =====");
@@ -728,6 +734,9 @@ contract IntegrationTest is BaseTest {
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
 
+        // Skip anti-snipe period (600 seconds + buffer)
+        vm.warp(block.timestamp + 3600); // 1 hour forward
+
         // Test costs
         uint256 cost800M = getQuoteForExactOutput(token, 800_000_000 * 10 ** token.decimals());
         uint256 cost900M = getQuoteForExactOutput(token, 900_000_000 * 10 ** token.decimals());
@@ -752,8 +761,9 @@ contract IntegrationTest is BaseTest {
     }
 
     function testLiquidity(IERC20Metadata token) internal {
-        // Setup
+        // Setup - ensure alice has enough WETH
         vm.startPrank(alice);
+        weth.deposit{value: 50000 ether}(); // Add more WETH for alice
         weth.approve(address(swapRouter), type(uint256).max);
 
         // Buy 900M
@@ -765,7 +775,7 @@ contract IntegrationTest is BaseTest {
                 recipient: alice,
                 deadline: block.timestamp + 1000,
                 amountOut: 900_000_000 * 10 ** token.decimals(),
-                amountInMaximum: 20000 ether,
+                amountInMaximum: 50000 ether, // Increased from 20000
                 sqrtPriceLimitX96: 0
             })
         );
@@ -773,9 +783,9 @@ contract IntegrationTest is BaseTest {
 
         // Quick simulation
         address trader = makeAddr("trader");
-        vm.deal(trader, 10000000 ether);
+        vm.deal(trader, 50000000 ether);
         vm.startPrank(trader);
-        weth.deposit{value: 10000000 ether}();
+        weth.deposit{value: 50000000 ether}();
         weth.approve(address(swapRouter), type(uint256).max);
 
         uint256 liq200k = 0;
@@ -1006,6 +1016,9 @@ contract IntegrationTest is BaseTest {
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
 
+        // Skip anti-snipe period (600 seconds + buffer)
+        vm.warp(block.timestamp + 3600); // 1 hour forward
+
         // Setup Alice
         vm.startPrank(alice);
         weth.deposit{value: 1000000000 ether}();
@@ -1077,6 +1090,9 @@ contract IntegrationTest is BaseTest {
             ipWorld.createIpToken(alice, "MEME", "Test Token", address(0), testStartTicks, testAllocations);
 
         IERC20Metadata token = IERC20Metadata(tokenAddr);
+
+        // Skip anti-snipe period (600 seconds + buffer)
+        vm.warp(block.timestamp + 3600); // 1 hour forward
 
         // Test costs
         uint256 cost800 = getQuoteForExactOutput(token, 800_000_000 * 1e18);

--- a/test/integration/OldIPAsset.t.sol
+++ b/test/integration/OldIPAsset.t.sol
@@ -141,11 +141,12 @@ contract OldIPAssetTest is BaseTest {
             keccak256(
                 abi.encode(
                     keccak256(
-                        "CREATE(address creator,int24[] startTick,uint256[] allocationList,uint256 nonce,uint256 deadline)"
+                        "CREATE(address creator,int24[] startTick,uint256[] allocationList,bool antiSnipe,uint256 nonce,uint256 deadline)"
                     ),
                     alice,
                     keccak256(abi.encodePacked(startTickList)),
                     keccak256(abi.encodePacked(allocationList)),
+                    false,
                     operator.nonces(alice),
                     block.timestamp + 1000
                 )
@@ -157,7 +158,7 @@ contract OldIPAssetTest is BaseTest {
 
         vm.prank(alice);
         (address pool, address token) = operator.createIpTokenWithSig{value: 1 ether}(
-            "OldIP Token", "OLDIP", OLD_IPA, startTickList, allocationList, block.timestamp + 1000, sig
+            "OldIP Token", "OLDIP", OLD_IPA, startTickList, allocationList, false, block.timestamp + 1000, sig
         );
 
         // Verify token was created
@@ -227,11 +228,12 @@ contract OldIPAssetTest is BaseTest {
             keccak256(
                 abi.encode(
                     keccak256(
-                        "CREATE(address creator,int24[] startTick,uint256[] allocationList,uint256 nonce,uint256 deadline)"
+                        "CREATE(address creator,int24[] startTick,uint256[] allocationList,bool antiSnipe,uint256 nonce,uint256 deadline)"
                     ),
                     alice,
                     keccak256(abi.encodePacked(startTickList)),
                     keccak256(abi.encodePacked(allocationList)),
+                    false,
                     operator.nonces(alice),
                     block.timestamp + 1000
                 )
@@ -243,7 +245,7 @@ contract OldIPAssetTest is BaseTest {
 
         vm.prank(alice);
         (, address tokenAddr) = operator.createIpTokenWithSig{value: 1 ether}(
-            "OldIP Token", "OLDIP", OLD_IPA, startTickList, allocationList, block.timestamp + 1000, sig
+            "OldIP Token", "OLDIP", OLD_IPA, startTickList, allocationList, false, block.timestamp + 1000, sig
         );
 
         // Now perform swaps to generate fees
@@ -319,7 +321,7 @@ contract OldIPAssetTest is BaseTest {
 
         vm.prank(address(operator));
         (address pool, address tokenAddr) =
-            ipWorld.createIpToken(alice, "Direct Harvest Test", "DHT", OLD_IPA, startTickList, allocationList);
+            ipWorld.createIpToken(alice, "Direct Harvest Test", "DHT", OLD_IPA, startTickList, allocationList, false);
 
         // Initial swap to setup pool
         swap(IUniswapV3Pool(pool), 1 ether);

--- a/test/integration/Operator.t.sol
+++ b/test/integration/Operator.t.sol
@@ -310,7 +310,7 @@ contract OperatorTest is BaseTest {
 
         assertEq(alice.balance, aliceBalanceBefore - 1 ether);
 
-        // Verify the deployed token is IPAntiSnipeToken by checking antiSnipeDuration
+        // Verify the deployed token is IPToken by checking antiSnipeDuration
         // We can't directly check the contract type, but we can verify it has anti-snipe features
         // by checking if it implements the expected interface
         assertTrue(token != address(0));

--- a/test/integration/Vesting.t.sol
+++ b/test/integration/Vesting.t.sol
@@ -22,7 +22,7 @@ contract VestingTest is BaseTest {
     function test_Vesting_CreatedUnverified() public {
         vm.prank(address(operator));
         (address pool, address tokenAddr) =
-            ipWorld.createIpToken(address(this), "chill", "CHILL", address(0), startTickList, allocationList);
+            ipWorld.createIpToken(address(this), "chill", "CHILL", address(0), startTickList, allocationList, false);
         swap(IUniswapV3Pool(pool), 1 ether);
 
         assertApproxEqAbs(
@@ -42,7 +42,7 @@ contract VestingTest is BaseTest {
         ipWorld.claimIp(ipaId, alice);
         assertEq(ipWorld.ipaRecipient(ipaId), address(alice));
         (address pool, address tokenAddr) =
-            ipWorld.createIpToken(address(this), "chill", "CHILL", ipaId, startTickList, allocationList);
+            ipWorld.createIpToken(address(this), "chill", "CHILL", ipaId, startTickList, allocationList, false);
         vm.stopPrank();
 
         swap(IUniswapV3Pool(pool), 1 ether);
@@ -98,7 +98,7 @@ contract VestingTest is BaseTest {
         ipWorld.claimIp(ipaId, alice);
         assertEq(ipWorld.ipaRecipient(ipaId), address(alice));
         (, address tokenAddr) =
-            ipWorld.createIpToken(address(this), "chill", "CHILL", ipaId, startTickList, allocationList);
+            ipWorld.createIpToken(address(this), "chill", "CHILL", ipaId, startTickList, allocationList, false);
         vm.stopPrank();
 
         // Harvest immediately without any swaps - no fees should have accrued

--- a/test/unit/IPToken.t.sol
+++ b/test/unit/IPToken.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {IPToken} from "../../src/IPToken.sol";
+import {Errors} from "../../src/lib/Errors.sol";
 import {Constants} from "../../utils/Constants.sol";
 import {IUniswapV3Factory} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
 import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
@@ -19,7 +20,7 @@ contract IPTokenTest is Test {
 
     function setUp() public {
         vm.createSelectFork(Constants.STORY_MAINNET_RPC);
-        ipToken = new IPToken(address(this), Constants.V3_DEPLOYER, Constants.WETH, 100 ether, "IP Token", "IPT");
+        ipToken = new IPToken(address(this), Constants.V3_DEPLOYER, Constants.WETH, 100 ether, 0, "IP Token", "IPT");
 
         v3Factory = IUniswapV3Factory(Constants.V3_FACTORY);
         liquidityPool = v3Factory.createPool(address(ipToken), Constants.WETH, V3_FEE);
@@ -31,5 +32,201 @@ contract IPTokenTest is Test {
         assertEq(ipToken.symbol(), "IPT");
         assertEq(ipToken.decimals(), 18);
         assertEq(ipToken.totalSupply(), 1e27);
+        assertEq(ipToken.antiSnipeDuration(), 0); // No anti-snipe for this test token
+    }
+
+    function test_AntiSnipe_DisabledByDefault() public {
+        // Create token with 0 anti-snipe duration (disabled)
+        IPToken tokenNoSnipe = new IPToken(
+            address(this),
+            Constants.V3_DEPLOYER,
+            Constants.WETH,
+            100 ether,
+            0, // No anti-snipe
+            "No Snipe Token",
+            "NST"
+        );
+
+        // First send tokens to liquidity pool
+        address poolAddr = tokenNoSnipe.liquidityPool();
+        tokenNoSnipe.transfer(poolAddr, 600_000_000 * 1e18);
+
+        // Should be able to transfer any amount from liquidity pool (no anti-snipe)
+        vm.prank(poolAddr);
+        tokenNoSnipe.transfer(address(1), 500_000_000 * 1e18); // More than MAX_SNIPER_AMOUNT
+
+        assertEq(tokenNoSnipe.balanceOf(address(1)), 500_000_000 * 1e18);
+    }
+
+    function test_AntiSnipe_EnabledBlocks() public {
+        // Create token with 600 second anti-snipe duration
+        IPToken tokenWithSnipe = new IPToken(
+            address(this),
+            Constants.V3_DEPLOYER,
+            Constants.WETH,
+            100 ether,
+            600, // 10 minute anti-snipe
+            "Snipe Protected Token",
+            "SPT"
+        );
+
+        // First send tokens to liquidity pool
+        address poolAddr = tokenWithSnipe.liquidityPool();
+        tokenWithSnipe.transfer(poolAddr, 600_000_000 * 1e18);
+
+        // Should revert when trying to transfer more than MAX_SNIPER_AMOUNT from liquidity pool
+        vm.prank(poolAddr);
+        vm.expectRevert(abi.encodeWithSelector(Errors.IPToken_ExceedsAntiSnipeLimit.selector));
+        tokenWithSnipe.transfer(address(1), 500_000_000 * 1e18); // More than MAX_SNIPER_AMOUNT
+
+        // Should allow transfers up to MAX_SNIPER_AMOUNT
+        vm.prank(poolAddr);
+        tokenWithSnipe.transfer(address(1), 300_000_000 * 1e18); // Exactly MAX_SNIPER_AMOUNT
+        assertEq(tokenWithSnipe.balanceOf(address(1)), 300_000_000 * 1e18);
+    }
+
+    function test_AntiSnipe_ExpiresAfterDuration() public {
+        // Create token with 1 second anti-snipe duration for quick testing
+        IPToken tokenWithSnipe = new IPToken(
+            address(this),
+            Constants.V3_DEPLOYER,
+            Constants.WETH,
+            100 ether,
+            1, // 1 second anti-snipe
+            "Short Snipe Token",
+            "SST"
+        );
+
+        // First send tokens to liquidity pool
+        address poolAddr = tokenWithSnipe.liquidityPool();
+        tokenWithSnipe.transfer(poolAddr, 600_000_000 * 1e18);
+
+        // Should revert initially
+        vm.prank(poolAddr);
+        vm.expectRevert(abi.encodeWithSelector(Errors.IPToken_ExceedsAntiSnipeLimit.selector));
+        tokenWithSnipe.transfer(address(1), 500_000_000 * 1e18);
+
+        // Wait 2 seconds
+        vm.warp(block.timestamp + 2);
+
+        // Should work after expiration
+        vm.prank(poolAddr);
+        tokenWithSnipe.transfer(address(1), 500_000_000 * 1e18);
+        assertEq(tokenWithSnipe.balanceOf(address(1)), 500_000_000 * 1e18);
+    }
+
+    function test_AntiSnipe_OnlyAppliesToLiquidityPool() public {
+        // Create token with anti-snipe enabled
+        IPToken tokenWithSnipe = new IPToken(
+            address(this),
+            Constants.V3_DEPLOYER,
+            Constants.WETH,
+            100 ether,
+            600, // 10 minute anti-snipe
+            "Snipe Protected Token",
+            "SPT"
+        );
+
+        // Regular transfers should not be affected
+        tokenWithSnipe.transfer(address(1), 500_000_000 * 1e18); // More than MAX_SNIPER_AMOUNT
+        assertEq(tokenWithSnipe.balanceOf(address(1)), 500_000_000 * 1e18);
+
+        // TransferFrom should also work normally for non-pool addresses
+        tokenWithSnipe.approve(address(2), 100_000_000 * 1e18);
+        vm.prank(address(2));
+        tokenWithSnipe.transferFrom(address(this), address(3), 100_000_000 * 1e18);
+        assertEq(tokenWithSnipe.balanceOf(address(3)), 100_000_000 * 1e18);
+    }
+
+    function test_AntiSnipe_TransferFromBlocked() public {
+        // Create token with anti-snipe enabled
+        IPToken tokenWithSnipe = new IPToken(
+            address(this),
+            Constants.V3_DEPLOYER,
+            Constants.WETH,
+            100 ether,
+            600, // 10 minute anti-snipe
+            "Snipe Protected Token",
+            "SPT"
+        );
+
+        address poolAddr = tokenWithSnipe.liquidityPool();
+
+        // First send tokens to liquidity pool
+        tokenWithSnipe.transfer(poolAddr, 600_000_000 * 1e18);
+
+        // Approve this contract to spend pool's tokens
+        vm.prank(poolAddr);
+        tokenWithSnipe.approve(address(this), 600_000_000 * 1e18);
+
+        // transferFrom from liquidity pool should also be blocked
+        vm.expectRevert(abi.encodeWithSelector(Errors.IPToken_ExceedsAntiSnipeLimit.selector));
+        tokenWithSnipe.transferFrom(poolAddr, address(1), 500_000_000 * 1e18);
+
+        // But smaller amounts should work
+        tokenWithSnipe.transferFrom(poolAddr, address(1), 300_000_000 * 1e18);
+        assertEq(tokenWithSnipe.balanceOf(address(1)), 300_000_000 * 1e18);
+    }
+
+    function test_AntiSnipe_TokenCreatorExemption() public {
+        // Create token with anti-snipe enabled, this contract is the creator
+        IPToken tokenWithSnipe = new IPToken(
+            address(this), // This contract is the creator
+            Constants.V3_DEPLOYER,
+            Constants.WETH,
+            100 ether,
+            600, // 10 minute anti-snipe
+            "Creator Exempt Token",
+            "CET"
+        );
+
+        address poolAddr = tokenWithSnipe.liquidityPool();
+
+        // First send tokens to liquidity pool
+        tokenWithSnipe.transfer(poolAddr, 900_000_000 * 1e18);
+
+        // Token creator should be able to buy any amount during anti-snipe period
+        vm.prank(poolAddr);
+        tokenWithSnipe.transfer(address(this), 800_000_000 * 1e18); // Way more than MAX_SNIPER_AMOUNT
+        assertEq(tokenWithSnipe.balanceOf(address(this)), 900_000_000 * 1e18); // 100M original + 800M bought
+
+        // But other addresses should still be blocked
+        vm.prank(poolAddr);
+        vm.expectRevert(abi.encodeWithSelector(Errors.IPToken_ExceedsAntiSnipeLimit.selector));
+        tokenWithSnipe.transfer(address(1), 500_000_000 * 1e18);
+    }
+
+    function test_AntiSnipe_CreatorExemptionTransferFrom() public {
+        // Create token with different creator address
+        address creator = makeAddr("creator");
+        IPToken tokenWithSnipe = new IPToken(
+            creator, // Different creator
+            Constants.V3_DEPLOYER,
+            Constants.WETH,
+            100 ether,
+            600, // 10 minute anti-snipe
+            "Creator Different Token",
+            "CDT"
+        );
+
+        address poolAddr = tokenWithSnipe.liquidityPool();
+
+        // First send tokens to liquidity pool
+        tokenWithSnipe.transfer(poolAddr, 900_000_000 * 1e18);
+
+        // Approve this contract to spend pool's tokens
+        vm.prank(poolAddr);
+        tokenWithSnipe.approve(address(this), 900_000_000 * 1e18);
+
+        // Creator should be able to buy any amount via transferFrom
+        tokenWithSnipe.transferFrom(poolAddr, creator, 800_000_000 * 1e18);
+        assertEq(tokenWithSnipe.balanceOf(creator), 800_000_000 * 1e18);
+
+        // But other addresses should still be blocked (need to approve more first)
+        vm.prank(poolAddr);
+        tokenWithSnipe.approve(address(this), type(uint256).max);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.IPToken_ExceedsAntiSnipeLimit.selector));
+        tokenWithSnipe.transferFrom(poolAddr, address(1), 500_000_000 * 1e18);
     }
 }

--- a/test/unit/IPToken.t.sol
+++ b/test/unit/IPToken.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {IPToken} from "../../src/IPToken.sol";
+import {IPAntiSnipeToken} from "../../src/IPAntiSnipeToken.sol";
 import {Errors} from "../../src/lib/Errors.sol";
 import {Constants} from "../../utils/Constants.sol";
 import {IUniswapV3Factory} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
@@ -20,7 +21,7 @@ contract IPTokenTest is Test {
 
     function setUp() public {
         vm.createSelectFork(Constants.STORY_MAINNET_RPC);
-        ipToken = new IPToken(address(this), Constants.V3_DEPLOYER, Constants.WETH, 100 ether, 0, "IP Token", "IPT");
+        ipToken = new IPToken(address(this), Constants.V3_DEPLOYER, Constants.WETH, 100 ether, "IP Token", "IPT");
 
         v3Factory = IUniswapV3Factory(Constants.V3_FACTORY);
         liquidityPool = v3Factory.createPool(address(ipToken), Constants.WETH, V3_FEE);
@@ -37,15 +38,8 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_DisabledByDefault() public {
         // Create token with 0 anti-snipe duration (disabled)
-        IPToken tokenNoSnipe = new IPToken(
-            address(this),
-            Constants.V3_DEPLOYER,
-            Constants.WETH,
-            100 ether,
-            0, // No anti-snipe
-            "No Snipe Token",
-            "NST"
-        );
+        IPToken tokenNoSnipe =
+            new IPToken(address(this), Constants.V3_DEPLOYER, Constants.WETH, 100 ether, "No Snipe Token", "NST");
 
         // First send tokens to liquidity pool
         address poolAddr = tokenNoSnipe.liquidityPool();
@@ -60,7 +54,7 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_EnabledBlocks() public {
         // Create token with 600 second anti-snipe duration
-        IPToken tokenWithSnipe = new IPToken(
+        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
             address(this),
             Constants.V3_DEPLOYER,
             Constants.WETH,
@@ -87,7 +81,7 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_ExpiresAfterDuration() public {
         // Create token with 1 second anti-snipe duration for quick testing
-        IPToken tokenWithSnipe = new IPToken(
+        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
             address(this),
             Constants.V3_DEPLOYER,
             Constants.WETH,
@@ -117,7 +111,7 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_OnlyAppliesToLiquidityPool() public {
         // Create token with anti-snipe enabled
-        IPToken tokenWithSnipe = new IPToken(
+        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
             address(this),
             Constants.V3_DEPLOYER,
             Constants.WETH,
@@ -140,7 +134,7 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_TransferFromBlocked() public {
         // Create token with anti-snipe enabled
-        IPToken tokenWithSnipe = new IPToken(
+        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
             address(this),
             Constants.V3_DEPLOYER,
             Constants.WETH,
@@ -170,7 +164,7 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_TokenCreatorExemption() public {
         // Create token with anti-snipe enabled, this contract is the creator
-        IPToken tokenWithSnipe = new IPToken(
+        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
             address(this), // This contract is the creator
             Constants.V3_DEPLOYER,
             Constants.WETH,
@@ -199,7 +193,7 @@ contract IPTokenTest is Test {
     function test_AntiSnipe_CreatorExemptionTransferFrom() public {
         // Create token with different creator address
         address creator = makeAddr("creator");
-        IPToken tokenWithSnipe = new IPToken(
+        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
             creator, // Different creator
             Constants.V3_DEPLOYER,
             Constants.WETH,

--- a/test/unit/IPToken.t.sol
+++ b/test/unit/IPToken.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {IPToken} from "../../src/IPToken.sol";
-import {IPAntiSnipeToken} from "../../src/IPAntiSnipeToken.sol";
 import {Errors} from "../../src/lib/Errors.sol";
 import {Constants} from "../../utils/Constants.sol";
 import {IUniswapV3Factory} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
@@ -21,7 +20,7 @@ contract IPTokenTest is Test {
 
     function setUp() public {
         vm.createSelectFork(Constants.STORY_MAINNET_RPC);
-        ipToken = new IPToken(address(this), Constants.V3_DEPLOYER, Constants.WETH, 100 ether, "IP Token", "IPT");
+        ipToken = new IPToken(address(this), Constants.V3_DEPLOYER, Constants.WETH, 100 ether, 0, "IP Token", "IPT");
 
         v3Factory = IUniswapV3Factory(Constants.V3_FACTORY);
         liquidityPool = v3Factory.createPool(address(ipToken), Constants.WETH, V3_FEE);
@@ -33,13 +32,13 @@ contract IPTokenTest is Test {
         assertEq(ipToken.symbol(), "IPT");
         assertEq(ipToken.decimals(), 18);
         assertEq(ipToken.totalSupply(), 1e27);
-        assertEq(ipToken.antiSnipeDuration(), 0); // No anti-snipe for this test token
+        // Regular IPToken doesn't have anti-snipe functionality
     }
 
     function test_AntiSnipe_DisabledByDefault() public {
         // Create token with 0 anti-snipe duration (disabled)
         IPToken tokenNoSnipe =
-            new IPToken(address(this), Constants.V3_DEPLOYER, Constants.WETH, 100 ether, "No Snipe Token", "NST");
+            new IPToken(address(this), Constants.V3_DEPLOYER, Constants.WETH, 100 ether, 0, "No Snipe Token", "NST");
 
         // First send tokens to liquidity pool
         address poolAddr = tokenNoSnipe.liquidityPool();
@@ -54,7 +53,7 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_EnabledBlocks() public {
         // Create token with 600 second anti-snipe duration
-        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
+        IPToken tokenWithSnipe = new IPToken(
             address(this),
             Constants.V3_DEPLOYER,
             Constants.WETH,
@@ -81,7 +80,7 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_ExpiresAfterDuration() public {
         // Create token with 1 second anti-snipe duration for quick testing
-        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
+        IPToken tokenWithSnipe = new IPToken(
             address(this),
             Constants.V3_DEPLOYER,
             Constants.WETH,
@@ -111,7 +110,7 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_OnlyAppliesToLiquidityPool() public {
         // Create token with anti-snipe enabled
-        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
+        IPToken tokenWithSnipe = new IPToken(
             address(this),
             Constants.V3_DEPLOYER,
             Constants.WETH,
@@ -134,7 +133,7 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_TransferFromBlocked() public {
         // Create token with anti-snipe enabled
-        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
+        IPToken tokenWithSnipe = new IPToken(
             address(this),
             Constants.V3_DEPLOYER,
             Constants.WETH,
@@ -164,7 +163,7 @@ contract IPTokenTest is Test {
 
     function test_AntiSnipe_TokenCreatorExemption() public {
         // Create token with anti-snipe enabled, this contract is the creator
-        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
+        IPToken tokenWithSnipe = new IPToken(
             address(this), // This contract is the creator
             Constants.V3_DEPLOYER,
             Constants.WETH,
@@ -193,7 +192,7 @@ contract IPTokenTest is Test {
     function test_AntiSnipe_CreatorExemptionTransferFrom() public {
         // Create token with different creator address
         address creator = makeAddr("creator");
-        IPAntiSnipeToken tokenWithSnipe = new IPAntiSnipeToken(
+        IPToken tokenWithSnipe = new IPToken(
             creator, // Different creator
             Constants.V3_DEPLOYER,
             Constants.WETH,

--- a/test/unit/IPWorld.t.sol
+++ b/test/unit/IPWorld.t.sol
@@ -19,7 +19,7 @@ contract IPWorldTest is BaseTest {
 
     function test_IPWorld_createIpNotOperator() public {
         vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
-        ipWorld.createIpToken(address(this), "chill", "CHILL", address(0), startTickList, allocationList);
+        ipWorld.createIpToken(address(this), "chill", "CHILL", address(0), startTickList, allocationList, false);
     }
 
     function test_IPWorld_createIpTokenGt() public {
@@ -43,8 +43,9 @@ contract IPWorldTest is BaseTest {
             abi.encode(true)
         );
         vm.prank(address(operator));
-        (, address tokenAddr) =
-            ipWorld.createIpToken(address(this), "chill", "CHILL", address(0x12345), startTickList, allocationList);
+        (, address tokenAddr) = ipWorld.createIpToken(
+            address(this), "chill", "CHILL", address(0x12345), startTickList, allocationList, false
+        );
         (address ipaId_, int24[] memory startTicks) = ipWorld.tokenInfo(tokenAddr);
         assertEq(ipaId_, ipaId);
         for (uint256 i = 0; i < startTickList.length; i++) {
@@ -64,8 +65,9 @@ contract IPWorldTest is BaseTest {
         ipWorld.claimIp(ipaId, alice);
 
         vm.prank(address(operator));
-        (, address tokenAddr) =
-            ipWorld.createIpToken(address(this), "chill", "CHILL", address(0x12345), startTickList, allocationList);
+        (, address tokenAddr) = ipWorld.createIpToken(
+            address(this), "chill", "CHILL", address(0x12345), startTickList, allocationList, false
+        );
         assertEq(ipWorld.getTokenIpRecipient(tokenAddr), alice);
     }
 
@@ -433,7 +435,7 @@ contract IPWorldTest is BaseTest {
     function _checkCreateIpToken() internal returns (address pool, address tokenAddr) {
         vm.prank(address(operator));
         (pool, tokenAddr) =
-            ipWorld.createIpToken(address(this), "chill", "CHILL", address(0), startTickList, allocationList);
+            ipWorld.createIpToken(address(this), "chill", "CHILL", address(0), startTickList, allocationList, false);
 
         // Verify pool was created correctly
         address actualPool = v3Factory.getPool(tokenAddr, address(weth), POOL_FEE);
@@ -475,7 +477,7 @@ contract IPWorldTest is BaseTest {
     function test_BidWall_DoS_Revert() public {
         vm.prank(address(operator));
         (, address tokenAddr) =
-            ipWorld.createIpToken(alice, "CHILL", "CHILL", address(0), startTickList, allocationList);
+            ipWorld.createIpToken(alice, "CHILL", "CHILL", address(0), startTickList, allocationList, false);
 
         IPToken ipToken = IPToken(tokenAddr);
 

--- a/utils/Constants.sol
+++ b/utils/Constants.sol
@@ -31,11 +31,18 @@ library Constants {
     address public constant SWAP_ROUTER_AENEID = 0x21bc5d68F6DA0E43A90f078bcCb04feddEdcC93b;
     address public constant QUOTER_V2_AENEID = 0x72897A551d217848E15c7d9f5981BfAd49b46969;
     address public constant NFT_POSITION_MANAGER_AENEID = 0xeE96404216dd0D6dbbe197ED1066B5CD414ef3b9;
+    address public constant SPG_NFT_AENEID = 0x8a0E4cb8bB4Fff61dF610c644515eb9467237489;
 
-    
-    // IPWorld mainnet contracts 
+
+    // IPWorld mainnet contracts
     address public constant IPWORLD = 0xd0EFb8Cd4c7a3Eefe823Fe963af9661D8F0CB745;
     address public constant IPOWNER_VAULT = 0x81336266Ba5F26B8AFf7d2b2A2305F52A39292b2;
+    address public constant SPG_NFT = 0x7A71F683969e9d6257DF68A910dfC22E33583af5;
+    address public constant ROYALTY_POLICY = 0x4027fc996DB0EaC23470e82c0Ce5D00fee42c26B;
+
+    // IPWorld testnet (AENEID) contracts
+    address public constant IPWORLD_AENEID = 0x77475A8ca1AfE6a6dc9E82B32210709054937099;
+    address public constant IPOWNER_VAULT_AENEID = 0x18C59E44B72A4B76FA3eE144F5E4f4fC177c1086;
     
     // Example old token for testing
     address public constant SONA_TOKEN = 0x02353a3BD5c9668159cF9Fd54AC61b03212FCf41;

--- a/utils/Constants.sol
+++ b/utils/Constants.sol
@@ -32,25 +32,26 @@ library Constants {
     address public constant SWAP_ROUTER_AENEID = 0x21bc5d68F6DA0E43A90f078bcCb04feddEdcC93b;
     address public constant QUOTER_V2_AENEID = 0x72897A551d217848E15c7d9f5981BfAd49b46969;
     address public constant NFT_POSITION_MANAGER_AENEID = 0xeE96404216dd0D6dbbe197ED1066B5CD414ef3b9;
-    address public constant SPG_NFT_AENEID = 0x8a0E4cb8bB4Fff61dF610c644515eb9467237489;
-
-
+    
     // IPWorld mainnet contracts
     address public constant IPWORLD = 0xd0EFb8Cd4c7a3Eefe823Fe963af9661D8F0CB745;
     address public constant IPOWNER_VAULT = 0x81336266Ba5F26B8AFf7d2b2A2305F52A39292b2;
     address public constant SPG_NFT = 0x7A71F683969e9d6257DF68A910dfC22E33583af5;
     address public constant ROYALTY_POLICY = 0x4027fc996DB0EaC23470e82c0Ce5D00fee42c26B;
+    address public constant EXPECTED_SIGNER = 0xC0CD5e9c5fE3D38CaB8516bB4fEf6e0FE59398FD;
 
     // IPWorld testnet (AENEID) contracts
     address public constant IPWORLD_AENEID = 0x77475A8ca1AfE6a6dc9E82B32210709054937099;
     address public constant IPOWNER_VAULT_AENEID = 0x18C59E44B72A4B76FA3eE144F5E4f4fC177c1086;
+    address public constant SPG_NFT_AENEID = 0xB2f1CA042da808e28b692368f953c674dD00F497;
+    address public constant ROYALTY_POLICY_AENEID = 0x70436E39110f3e3923736B618888E17E764E796B;
+    address public constant EXPECTED_SIGNER_AENEID = 0x21a75A970a35967e990C817998373C60268a9eA6;
     
     // Example old token for testing
     address public constant SONA_TOKEN = 0x02353a3BD5c9668159cF9Fd54AC61b03212FCf41;
     
     // IPWorld deployment
     address public constant OWNER = 0x527b390cD37643F10dA8B8Dca980FA46EEe2f58b;
-    address public constant EXPECTED_SIGNER = 0x527b390cD37643F10dA8B8Dca980FA46EEe2f58b;
     
     // IPWorld deployment parameters
     uint24 public constant BURN_SHARE = 500_000;


### PR DESCRIPTION
## Summary
- Implement 600-second anti-snipe protection period after token creation
- Limit transfers from liquidity pool to 300M tokens during protection period  
- Exempt token creators from transfer limits to allow initial purchases
- Maintain backward compatibility with existing deployed tokens (antiSnipeDuration=0 means no limit)
- Update interfaces (IIPToken, IIPWorld) to reflect new anti-snipe functionality
- Fix all integration tests with proper time warping to bypass anti-snipe period

## Key Changes
- **IPToken.sol**: Add anti-snipe protection via transfer/transferFrom overrides
- **IPWorld.sol**: Add ANTI_SNIPE_DURATION constant (600 seconds)
- **IPTokenDeployer.sol**: Pass antiSnipeDuration parameter to token constructor
- **Integration tests**: Add vm.warp calls to skip anti-snipe period in tests
- **Error handling**: Add IPToken_ExceedsAntiSnipeLimit error

## Test Coverage
- ✅ Anti-snipe protection enabled/disabled scenarios
- ✅ Transfer limit enforcement during protection period
- ✅ Token creator exemption from limits
- ✅ Protection period expiration
- ✅ transferFrom protection
- ✅ All integration tests passing with proper time handling

## Backward Compatibility
- Existing tokens with antiSnipeDuration=0 have no transfer limits
- New tokens get 600-second protection period automatically
- No breaking changes to existing deployed contracts

🤖 Generated with [Claude Code](https://claude.ai/code)