### PR TITLE
Separate token airdrop share from ETH airdrop share

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Show Forge version
         run: |

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,3 +6,12 @@ auto_detect_solc = true
 optimizer = true
 optimizer_runs = 10000
 via_ir = true
+
+[profile.ci]
+src = "src"
+out = "out"
+libs = ["lib"]
+auto_detect_solc = true
+optimizer = true
+optimizer_runs = 10000
+via_ir = true

--- a/src/IPWorld.sol
+++ b/src/IPWorld.sol
@@ -83,6 +83,8 @@ contract IPWorld is
 
     uint24 public immutable airdropShare;
 
+    uint24 public immutable tokenAirdropShare;
+
     uint24 public immutable ipOwnerShare;
 
     uint24 public immutable buybackShare;
@@ -137,6 +139,7 @@ contract IPWorld is
     /// @param tokenDeployer_ Address of the IP token deployer contract
     /// @param creationFee_ Fee required to create an IP token
     /// @param referralShare_ Percentage of fees allocated to referrals (out of 1,000,000)
+    /// @param tokenAirdropShare_ Percentage of token fees allocated to airdrop pool (out of 1,000,000)
     constructor(
         address weth_,
         address v3Deployer_,
@@ -149,7 +152,8 @@ contract IPWorld is
         uint24 buybackShare_,
         uint256 bidWallAmount_,
         uint256 creationFee_,
-        uint24 referralShare_
+        uint24 referralShare_,
+        uint24 tokenAirdropShare_
     ) {
         if (
             weth_ == address(0) ||
@@ -164,6 +168,9 @@ contract IPWorld is
         if (ipOwnerShare_ + buybackShare_ + airdropShare_ + referralShare_ > PRECISION) {
             revert Errors.IPWorld_InvalidShare();
         }
+        if (tokenAirdropShare_ > PRECISION) {
+            revert Errors.IPWorld_InvalidShare();
+        }
         _weth = weth_;
         _v3Deployer = v3Deployer_;
         _v3Factory = IUniswapV3Factory(v3Factory_);
@@ -176,6 +183,7 @@ contract IPWorld is
         bidWallAmount = bidWallAmount_;
         creationFee = creationFee_;
         referralShare = referralShare_;
+        tokenAirdropShare = tokenAirdropShare_;
         _disableInitializers();
     }
 
@@ -507,7 +515,7 @@ contract IPWorld is
         uint256 tokenAirdropAmount;
         uint256 emitTokenTreasuryAmount;
         if (tokenAmount > 0) {
-            tokenAirdropAmount = (tokenAmount * airdropShare) / PRECISION;
+            tokenAirdropAmount = (tokenAmount * tokenAirdropShare) / PRECISION;
             tokenTreasuryAmount = tokenAmount - tokenAirdropAmount;
 
             // Handle treasury distribution based on ipTreasury (per-IPA)

--- a/src/IPWorld.sol
+++ b/src/IPWorld.sol
@@ -3,30 +3,16 @@ pragma solidity ^0.8.26;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import {
-    IERC721Receiver
-} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import {
-    Ownable2StepUpgradeable
-} from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
-import {
-    UUPSUpgradeable
-} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
-import {
-    IUniswapV3Factory
-} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
-import {
-    IUniswapV3Pool
-} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+import {IUniswapV3Factory} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
+import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {TickMath} from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
-import {
-    LiquidityAmounts
-} from "@uniswap/v3-periphery/contracts/libraries/LiquidityAmounts.sol";
+import {LiquidityAmounts} from "@uniswap/v3-periphery/contracts/libraries/LiquidityAmounts.sol";
 
-import {
-    IStoryHuntV3MintCallback
-} from "./interfaces/storyhunt/IStoryHuntV3MintCallback.sol";
+import {IStoryHuntV3MintCallback} from "./interfaces/storyhunt/IStoryHuntV3MintCallback.sol";
 
 import {TokenInfoLibrary, TokenInfo} from "./lib/TokenInfo.sol";
 import {IIPWorld} from "./interfaces/IIPWorld.sol";
@@ -39,13 +25,7 @@ import {Errors} from "./lib/Errors.sol";
 /// @title IPWorld
 /// @notice Main platform contract for launching IP-backed memecoins with one-sided Uniswap V3 liquidity
 /// @dev Manages token deployment, IP linking, LP management, and fee distribution. Upgradeable via UUPS.
-contract IPWorld is
-    IIPWorld,
-    IStoryHuntV3MintCallback,
-    Ownable2StepUpgradeable,
-    UUPSUpgradeable,
-    IERC721Receiver
-{
+contract IPWorld is IIPWorld, IStoryHuntV3MintCallback, Ownable2StepUpgradeable, UUPSUpgradeable, IERC721Receiver {
     using TickMath for int24;
     using TokenInfoLibrary for TokenInfo;
     using TokenInfoLibrary for mapping(address token => TokenInfo);
@@ -62,8 +42,7 @@ contract IPWorld is
     int24 private constant TICK_SPACING = 200;
 
     /// @notice Maximum valid tick for LP positions (adjusted for tick spacing)
-    int24 private constant MAX_TICK =
-        TickMath.MAX_TICK - (TickMath.MAX_TICK % TICK_SPACING);
+    int24 private constant MAX_TICK = TickMath.MAX_TICK - (TickMath.MAX_TICK % TICK_SPACING);
 
     /// @notice Address of Wrapped Ether contract for trading pairs
     address private immutable _weth;
@@ -106,8 +85,7 @@ contract IPWorld is
     mapping(address ipaId => address recipient) private _ipaRecipient;
 
     /// @notice Maps IP asset identifiers to their pending reward recipients
-    mapping(address ipaId => address pendingRecipient)
-        private _ipaPendingRecipient;
+    mapping(address ipaId => address pendingRecipient) private _ipaPendingRecipient;
 
     /// @notice Per-IPA treasury address (immutable once set)
     mapping(address ipaId => address) public ipTreasury;
@@ -156,12 +134,8 @@ contract IPWorld is
         uint24 tokenAirdropShare_
     ) {
         if (
-            weth_ == address(0) ||
-            v3Deployer_ == address(0) ||
-            v3Factory_ == address(0) ||
-            ownerVault_ == address(0) ||
-            treasury_ == address(0) ||
-            tokenDeployer_ == address(0)
+            weth_ == address(0) || v3Deployer_ == address(0) || v3Factory_ == address(0) || ownerVault_ == address(0)
+                || treasury_ == address(0) || tokenDeployer_ == address(0)
         ) {
             revert Errors.IPWorld_InvalidAddress();
         }
@@ -206,33 +180,20 @@ contract IPWorld is
     /// Getters and Setters
     ///
 
-    function tokenInfo(
-        address token
-    )
-        external
-        view
-        override
-        returns (address ipaId, int24[] memory startTicks)
-    {
+    function tokenInfo(address token) external view override returns (address ipaId, int24[] memory startTicks) {
         return _tokenInfo[token].decode();
     }
 
-    function ipaRecipient(
-        address ipaId
-    ) external view override returns (address) {
+    function ipaRecipient(address ipaId) external view override returns (address) {
         return _ipaRecipient[ipaId];
     }
 
-    function ipaPendingRecipient(
-        address ipaId
-    ) external view override returns (address) {
+    function ipaPendingRecipient(address ipaId) external view override returns (address) {
         return _ipaPendingRecipient[ipaId];
     }
 
-    function getTokenIpRecipient(
-        address token
-    ) external view returns (address) {
-        (address ipaId, ) = _tokenInfo[token].decode();
+    function getTokenIpRecipient(address token) external view returns (address) {
+        (address ipaId,) = _tokenInfo[token].decode();
         return _ipaRecipient[ipaId];
     }
 
@@ -253,11 +214,7 @@ contract IPWorld is
     /// IP Asset Management
     ///
 
-    function claimIp(
-        address ipaId,
-        address recipient,
-        address referral_
-    ) external onlyOperator(OperatorType.Protocol) {
+    function claimIp(address ipaId, address recipient, address referral_) external onlyOperator(OperatorType.Protocol) {
         if (ipaId == address(0) || recipient == address(0)) {
             revert Errors.IPWorld_InvalidAddress();
         }
@@ -295,10 +252,7 @@ contract IPWorld is
         emit Claimed(ipaId, pendingRecipient);
     }
 
-    function setIpTreasury(
-        address ipaId,
-        address treasury_
-    ) external onlyOperator(OperatorType.Protocol) {
+    function setIpTreasury(address ipaId, address treasury_) external onlyOperator(OperatorType.Protocol) {
         if (treasury_ == address(0)) {
             revert Errors.IPWorld_InvalidIpTreasury();
         }
@@ -309,10 +263,7 @@ contract IPWorld is
         emit IpTreasurySet(ipaId, treasury_);
     }
 
-    function setReferral(
-        address ipaId,
-        address newReferral
-    ) external onlyOperator(OperatorType.Protocol) {
+    function setReferral(address ipaId, address newReferral) external onlyOperator(OperatorType.Protocol) {
         if (newReferral == address(0)) {
             revert Errors.IPWorld_InvalidReferral();
         }
@@ -335,10 +286,7 @@ contract IPWorld is
         emit ReferralSet(ipaId, pendingRef);
     }
 
-    function linkTokensToIp(
-        address ipaId,
-        address[] calldata tokenList
-    ) external onlyOperator(OperatorType.Protocol) {
+    function linkTokensToIp(address ipaId, address[] calldata tokenList) external onlyOperator(OperatorType.Protocol) {
         if (ipaId == address(0)) {
             revert Errors.IPWorld_InvalidAddress();
         }
@@ -372,7 +320,7 @@ contract IPWorld is
 
         // CEI: Interactions - Transfer fee to treasury before state changes
         if (creationFee > 0) {
-            (bool success, ) = treasury.call{value: msg.value}("");
+            (bool success,) = treasury.call{value: msg.value}("");
             if (!success) revert Errors.IPWorld_FeeTransferFailed();
         }
 
@@ -380,37 +328,21 @@ contract IPWorld is
             revert Errors.IPWorld_InvalidAddress();
         }
         uint256 length = startTickList.length;
-        if (
-            length != allocationList.length ||
-            length > TokenInfoLibrary.MAX_LP ||
-            length == 0
-        ) {
+        if (length != allocationList.length || length > TokenInfoLibrary.MAX_LP || length == 0) {
             revert Errors.IPWorld_InvalidTick();
         }
 
         uint256 antiSnipeDuration = antiSnipe ? ANTI_SNIPE_DURATION : 0;
         token = _tokenDeployer.deployToken(
-            tokenCreator,
-            _v3Deployer,
-            _weth,
-            bidWallAmount,
-            antiSnipeDuration,
-            name,
-            symbol
+            tokenCreator, _v3Deployer, _weth, bidWallAmount, antiSnipeDuration, name, symbol
         );
         pool = _v3Factory.getPool(token, _weth, V3_FEE);
         if (pool == address(0)) {
             pool = _v3Factory.createPool(token, _weth, V3_FEE);
         }
-        emit TokenDeployed(
-            tokenCreator,
-            token,
-            pool,
-            startTickList,
-            allocationList
-        );
+        emit TokenDeployed(tokenCreator, token, pool, startTickList, allocationList);
 
-        (uint160 sqrtRatioX96, , , , , , ) = IUniswapV3Pool(pool).slot0();
+        (uint160 sqrtRatioX96,,,,,,) = IUniswapV3Pool(pool).slot0();
         if (sqrtRatioX96 == 0) {
             int24 initialTick = _weth < token ? MAX_TICK : -MAX_TICK;
             uint160 initialSqrtPrice = initialTick.getSqrtRatioAtTick();
@@ -425,22 +357,11 @@ contract IPWorld is
         uint256 totalSupply = IERC20(token).totalSupply();
         for (uint256 i = 1; i <= length; ++i) {
             int24 nextTick = (i == length) ? MAX_TICK : startTickList[i];
-            if (
-                startTick < TickMath.MIN_TICK ||
-                startTick >= nextTick ||
-                nextTick % TICK_SPACING != 0
-            ) {
+            if (startTick < TickMath.MIN_TICK || startTick >= nextTick || nextTick % TICK_SPACING != 0) {
                 revert Errors.IPWorld_InvalidTick();
             }
-            uint256 liquidity = (totalSupply * allocationList[i - 1]) /
-                PRECISION;
-            _addLiquidity(
-                token,
-                IUniswapV3Pool(pool),
-                liquidity,
-                startTick,
-                nextTick
-            );
+            uint256 liquidity = (totalSupply * allocationList[i - 1]) / PRECISION;
+            _addLiquidity(token, IUniswapV3Pool(pool), liquidity, startTick, nextTick);
             startTick = nextTick;
         }
 
@@ -464,17 +385,14 @@ contract IPWorld is
         if (token == address(0)) {
             revert Errors.IPWorld_InvalidAddress();
         }
-        (address ipaId, int24[] memory startTickList) = _tokenInfo[token]
-            .decode();
+        (address ipaId, int24[] memory startTickList) = _tokenInfo[token].decode();
         uint256 length = startTickList.length;
         if (length == 0) {
             revert Errors.IPWorld_WrongToken();
         }
 
         // Look up the 1% pool from factory (all tokens use 1% pool after migration)
-        IUniswapV3Pool pool = IUniswapV3Pool(
-            _v3Factory.getPool(_weth, token, V3_FEE)
-        );
+        IUniswapV3Pool pool = IUniswapV3Pool(_v3Factory.getPool(_weth, token, V3_FEE));
         if (address(pool) == address(0)) {
             revert Errors.IPWorld_WrongToken();
         }
@@ -488,7 +406,7 @@ contract IPWorld is
         }
         bool isNativeZero = _weth < token;
 
-        (, int24 currentTick, , , , , ) = pool.slot0();
+        (, int24 currentTick,,,,,) = pool.slot0();
         if (isNativeZero) currentTick = -currentTick;
 
         int24 startTick;
@@ -503,12 +421,7 @@ contract IPWorld is
         }
 
         /// @dev Collect fees from the current active liquidity position
-        (uint256 wethAmount, uint256 tokenAmount) = _collectLiquidity(
-            pool,
-            startTick,
-            nextTick,
-            isNativeZero
-        );
+        (uint256 wethAmount, uint256 tokenAmount) = _collectLiquidity(pool, startTick, nextTick, isNativeZero);
 
         /// @dev Distribute token fees: airdrop pool + ipTreasury (or pendingTreasury)
         uint256 tokenTreasuryAmount;
@@ -526,8 +439,9 @@ contract IPWorld is
                 uint256 totalTreasuryAmount = tokenTreasuryAmount + pending;
                 if (pending > 0) pendingTreasury[token] = 0;
                 IERC20(token).transfer(ipTreasury_, totalTreasuryAmount);
-                if (pending > 0)
+                if (pending > 0) {
                     emit TreasuryFlushed(token, ipTreasury_, pending);
+                }
             } else {
                 emitTokenTreasuryAmount = 0;
                 pendingTreasury[token] += tokenTreasuryAmount;
@@ -538,10 +452,7 @@ contract IPWorld is
         address recipient = _ipaRecipient[ipaId];
 
         // Create vesting schedule if recipient exists and vesting not yet set
-        if (
-            recipient != address(0) &&
-            !IIPOwnerVault(ownerVault).vesting(token).isSet
-        ) {
+        if (recipient != address(0) && !IIPOwnerVault(ownerVault).vesting(token).isSet) {
             IIPOwnerVault(ownerVault).createVestingOnTokenDeploy(token);
         }
 
@@ -553,7 +464,7 @@ contract IPWorld is
             if (i == 0) {
                 // 1st LP: 100% to protocol treasury
                 IWETH9(_weth).withdraw(wethAmount);
-                (bool success, ) = treasury.call{value: wethAmount}("");
+                (bool success,) = treasury.call{value: wethAmount}("");
                 if (!success) revert();
             } else {
                 // 2nd+ LP: all shares on full wethAmount
@@ -568,11 +479,7 @@ contract IPWorld is
                     referralAmount = (wethAmount * referralShare) / PRECISION;
                 }
 
-                uint256 treasuryAmount = wethAmount -
-                    buybackAmount -
-                    ipOwnerAmount -
-                    wethAirdropAmount -
-                    referralAmount;
+                uint256 treasuryAmount = wethAmount - buybackAmount - ipOwnerAmount - wethAirdropAmount - referralAmount;
 
                 // Accumulate WETH airdrop (keep as WETH)
                 wethAirdropPool[token] += wethAirdropAmount;
@@ -590,15 +497,13 @@ contract IPWorld is
                 uint256 wethToWithdraw = ipOwnerAmount + treasuryAmount + referralAmount;
                 IWETH9(_weth).withdraw(wethToWithdraw);
 
-                (bool success, ) = treasury.call{value: treasuryAmount}("");
+                (bool success,) = treasury.call{value: treasuryAmount}("");
                 if (!success) revert();
 
-                IIPOwnerVault(ownerVault).distributeOwdAmount{
-                    value: ipOwnerAmount
-                }(token);
+                IIPOwnerVault(ownerVault).distributeOwdAmount{value: ipOwnerAmount}(token);
 
                 if (referralAmount > 0) {
-                    (bool success2, ) = ref.call{value: referralAmount}("");
+                    (bool success2,) = ref.call{value: referralAmount}("");
                     if (!success2) revert();
                     emit ReferralFeePaid(token, ipaId, ref, referralAmount);
                 }
@@ -622,7 +527,10 @@ contract IPWorld is
     /// Token Management
     ///
 
-    enum AirdropType { UGC, Holder }
+    enum AirdropType {
+        UGC,
+        Holder
+    }
 
     function claimAirdropUgc(
         address token,
@@ -670,8 +578,7 @@ contract IPWorld is
         }
 
         // tokenAirdropPool = balance - pendingTreasury (no storage)
-        uint256 availableTokenPool = IERC20(token).balanceOf(address(this)) -
-            pendingTreasury[token];
+        uint256 availableTokenPool = IERC20(token).balanceOf(address(this)) - pendingTreasury[token];
         if (totalTokenAmount > availableTokenPool) {
             revert Errors.IPWorld_InsufficientAirdropPool();
         }
@@ -687,24 +594,16 @@ contract IPWorld is
             if (recipient == address(0)) {
                 revert Errors.IPWorld_InvalidAddress();
             }
-            if (tokenAmounts[i] > 0)
+            if (tokenAmounts[i] > 0) {
                 IERC20(token).transfer(recipient, tokenAmounts[i]);
-            if (wethAmounts[i] > 0)
+            }
+            if (wethAmounts[i] > 0) {
                 IERC20(_weth).transfer(recipient, wethAmounts[i]);
+            }
             if (airdropType == AirdropType.UGC) {
-                emit AirdropClaimedUgc(
-                    token,
-                    recipient,
-                    tokenAmounts[i],
-                    wethAmounts[i]
-                );
+                emit AirdropClaimedUgc(token, recipient, tokenAmounts[i], wethAmounts[i]);
             } else {
-                emit AirdropClaimedHolder(
-                    token,
-                    recipient,
-                    tokenAmounts[i],
-                    wethAmounts[i]
-                );
+                emit AirdropClaimedHolder(token, recipient, tokenAmounts[i], wethAmounts[i]);
             }
         }
     }
@@ -736,17 +635,9 @@ contract IPWorld is
         uint128 liquidity;
 
         if (nativeIsZero) {
-            liquidity = LiquidityAmounts.getLiquidityForAmount1(
-                lowerSqrtPriceX96,
-                upperSqrtPriceX96,
-                tokenForLiquidity
-            );
+            liquidity = LiquidityAmounts.getLiquidityForAmount1(lowerSqrtPriceX96, upperSqrtPriceX96, tokenForLiquidity);
         } else {
-            liquidity = LiquidityAmounts.getLiquidityForAmount0(
-                lowerSqrtPriceX96,
-                upperSqrtPriceX96,
-                tokenForLiquidity
-            );
+            liquidity = LiquidityAmounts.getLiquidityForAmount0(lowerSqrtPriceX96, upperSqrtPriceX96, tokenForLiquidity);
         }
         if (liquidity == 0) return;
 
@@ -754,14 +645,7 @@ contract IPWorld is
         pool.mint(address(this), tickLower, tickUpper, liquidity, data);
 
         // Emit event with original tick values (before potential swap)
-        emit LiquidityDeployed(
-            token,
-            address(pool),
-            originalTickLower,
-            originalTickUpper,
-            liquidity,
-            tokenForLiquidity
-        );
+        emit LiquidityDeployed(token, address(pool), originalTickLower, originalTickUpper, liquidity, tokenForLiquidity);
     }
 
     /// @notice Collects all liquidity and fees from a specific tick range position
@@ -771,12 +655,10 @@ contract IPWorld is
     /// @param nativeIsZero Whether WETH is token0 in the pool
     /// @return wethAmount Amount of WETH collected
     /// @return tokenAmount Amount of IP tokens collected
-    function _collectLiquidity(
-        IUniswapV3Pool pool,
-        int24 tickLower,
-        int24 tickUpper,
-        bool nativeIsZero
-    ) internal returns (uint256 wethAmount, uint256 tokenAmount) {
+    function _collectLiquidity(IUniswapV3Pool pool, int24 tickLower, int24 tickUpper, bool nativeIsZero)
+        internal
+        returns (uint256 wethAmount, uint256 tokenAmount)
+    {
         // Store original ticks for event
         int24 originalTickLower = tickLower;
         int24 originalTickUpper = tickUpper;
@@ -784,31 +666,15 @@ contract IPWorld is
         if (nativeIsZero) {
             (tickLower, tickUpper) = (-tickUpper, -tickLower);
             pool.burn(tickLower, tickUpper, 0);
-            (wethAmount, tokenAmount) = pool.collect(
-                address(this),
-                tickLower,
-                tickUpper,
-                type(uint128).max,
-                type(uint128).max
-            );
+            (wethAmount, tokenAmount) =
+                pool.collect(address(this), tickLower, tickUpper, type(uint128).max, type(uint128).max);
         } else {
             pool.burn(tickLower, tickUpper, 0);
-            (tokenAmount, wethAmount) = pool.collect(
-                address(this),
-                tickLower,
-                tickUpper,
-                type(uint128).max,
-                type(uint128).max
-            );
+            (tokenAmount, wethAmount) =
+                pool.collect(address(this), tickLower, tickUpper, type(uint128).max, type(uint128).max);
         }
 
-        emit LiquidityCollected(
-            address(pool),
-            originalTickLower,
-            originalTickUpper,
-            wethAmount,
-            tokenAmount
-        );
+        emit LiquidityCollected(address(pool), originalTickLower, originalTickUpper, wethAmount, tokenAmount);
     }
 
     ///
@@ -820,11 +686,7 @@ contract IPWorld is
     /// @param amount0Owed Amount of token0 required for liquidity transfer
     /// @param amount1Owed Amount of token1 required for liquidity transfer
     /// @param data Additional data passed by the caller
-    function storyHuntV3MintCallback(
-        uint256 amount0Owed,
-        uint256 amount1Owed,
-        bytes calldata data
-    ) external {
+    function storyHuntV3MintCallback(uint256 amount0Owed, uint256 amount1Owed, bytes calldata data) external {
         address token = abi.decode(data, (address));
 
         // Accept callback only from the 1% pool
@@ -835,30 +697,17 @@ contract IPWorld is
 
         bool nativeIsZero = _weth < token;
         if (amount0Owed > 0) {
-            IERC20(nativeIsZero ? _weth : token).transfer(
-                msg.sender,
-                amount0Owed
-            );
+            IERC20(nativeIsZero ? _weth : token).transfer(msg.sender, amount0Owed);
         }
         if (amount1Owed > 0) {
-            IERC20(nativeIsZero ? token : _weth).transfer(
-                msg.sender,
-                amount1Owed
-            );
+            IERC20(nativeIsZero ? token : _weth).transfer(msg.sender, amount1Owed);
         }
     }
 
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal override onlyOwner {}
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     /// @notice Ensures Story IPA NFTs can be received on registration
-    function onERC721Received(
-        address,
-        address,
-        uint256,
-        bytes calldata
-    ) external pure returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes calldata) external pure returns (bytes4) {
         return IERC721Receiver.onERC721Received.selector;
     }
 

--- a/src/IPWorld.sol
+++ b/src/IPWorld.sol
@@ -95,7 +95,7 @@ contract IPWorld is
     /// @notice Share of LP fees designated as referral fee
     uint24 public immutable referralShare;
 
-    mapping(address operator => bool) public isOperator;
+    mapping(address operator => OperatorType) public isOperator;
 
     /// @notice Stores token information including IP asset linkage and tick configurations
     mapping(address token => TokenInfo) private _tokenInfo;
@@ -185,9 +185,10 @@ contract IPWorld is
         _transferOwnership(initialOwner);
     }
 
-    /// @notice Restricts calls to only be made through enrolled operators
-    modifier onlyOperator() {
-        if (!isOperator[msg.sender]) {
+    /// @notice Restricts calls to only be made through enrolled operators of a specific type
+    /// @param requiredType The operator type required to call the function
+    modifier onlyOperator(OperatorType requiredType) {
+        if (isOperator[msg.sender] != requiredType) {
             revert Errors.IPWorld_OperatorOnly();
         }
         _;
@@ -232,12 +233,12 @@ contract IPWorld is
         return IERC20(token).balanceOf(address(this)) - pendingTreasury[token];
     }
 
-    function setOperator(address operator, bool status) external onlyOwner {
+    function setOperator(address operator, OperatorType operatorType) external onlyOwner {
         if (operator == treasury) {
             revert Errors.IPWorld_InvalidAddress();
         }
-        isOperator[operator] = status;
-        emit SetOperator(operator, status);
+        isOperator[operator] = operatorType;
+        emit SetOperator(operator, operatorType);
     }
 
     ///
@@ -248,7 +249,7 @@ contract IPWorld is
         address ipaId,
         address recipient,
         address referral_
-    ) external onlyOperator {
+    ) external onlyOperator(OperatorType.Protocol) {
         if (ipaId == address(0) || recipient == address(0)) {
             revert Errors.IPWorld_InvalidAddress();
         }
@@ -289,7 +290,7 @@ contract IPWorld is
     function setIpTreasury(
         address ipaId,
         address treasury_
-    ) external onlyOperator {
+    ) external onlyOperator(OperatorType.Protocol) {
         if (treasury_ == address(0)) {
             revert Errors.IPWorld_InvalidIpTreasury();
         }
@@ -303,7 +304,7 @@ contract IPWorld is
     function setReferral(
         address ipaId,
         address newReferral
-    ) external onlyOperator {
+    ) external onlyOperator(OperatorType.Protocol) {
         if (newReferral == address(0)) {
             revert Errors.IPWorld_InvalidReferral();
         }
@@ -329,7 +330,7 @@ contract IPWorld is
     function linkTokensToIp(
         address ipaId,
         address[] calldata tokenList
-    ) external onlyOperator {
+    ) external onlyOperator(OperatorType.Protocol) {
         if (ipaId == address(0)) {
             revert Errors.IPWorld_InvalidAddress();
         }
@@ -355,7 +356,7 @@ contract IPWorld is
         int24[] calldata startTickList,
         uint256[] calldata allocationList,
         bool antiSnipe
-    ) external payable onlyOperator returns (address pool, address token) {
+    ) external payable onlyOperator(OperatorType.Protocol) returns (address pool, address token) {
         // CEI: Checks - Validate fee
         if (msg.value != creationFee) {
             revert Errors.IPWorld_InvalidFee();
@@ -620,7 +621,7 @@ contract IPWorld is
         address[] calldata recipients,
         uint256[] calldata tokenAmounts,
         uint256[] calldata wethAmounts
-    ) external onlyOperator {
+    ) external onlyOperator(OperatorType.Airdrop) {
         _claimAirdrop(token, recipients, tokenAmounts, wethAmounts, AirdropType.UGC);
     }
 
@@ -629,7 +630,7 @@ contract IPWorld is
         address[] calldata recipients,
         uint256[] calldata tokenAmounts,
         uint256[] calldata wethAmounts
-    ) external onlyOperator {
+    ) external onlyOperator(OperatorType.Airdrop) {
         _claimAirdrop(token, recipients, tokenAmounts, wethAmounts, AirdropType.Holder);
     }
 

--- a/src/IPWorld.sol
+++ b/src/IPWorld.sol
@@ -295,6 +295,10 @@ contract IPWorld is IIPWorld, IStoryHuntV3MintCallback, Ownable2StepUpgradeable,
             if (token == address(0)) {
                 revert Errors.IPWorld_InvalidAddress();
             }
+            (, int24[] memory startTicks) = _tokenInfo[token].decode();
+            if (startTicks.length == 0) {
+                revert Errors.IPWorld_WrongToken();
+            }
             _tokenInfo.updateTokenInfo(token, ipaId);
             emit Linked(ipaId, token);
         }

--- a/src/IPWorldRoyaltyPolicy.sol
+++ b/src/IPWorldRoyaltyPolicy.sol
@@ -16,6 +16,13 @@ contract IPWorldRoyaltyPolicy is IGraphAwareRoyaltyPolicy, Ownable2StepUpgradeab
         _transferOwnership(initialOwner);
     }
 
+    /// @notice V2 initializer for upgrading from v1 (no-owner) to v2 (with owner)
+    /// @param newOwner Address of the contract owner
+    function initializeV2(address newOwner) public reinitializer(2) {
+        __Ownable2Step_init();
+        _transferOwnership(newOwner);
+    }
+
     /// @notice No-op for license minting hook
     function onLicenseMinting(address, uint32, bytes calldata) external override {}
 

--- a/src/interfaces/IIPWorld.sol
+++ b/src/interfaces/IIPWorld.sol
@@ -144,6 +144,10 @@ interface IIPWorld {
     /// @return Percentage share of fees for airdrop (out of PRECISION)
     function airdropShare() external view returns (uint24);
 
+    /// @notice Share of token fees allocated to airdrop pool
+    /// @return Percentage share of token fees for airdrop (out of PRECISION)
+    function tokenAirdropShare() external view returns (uint24);
+
     /// @notice Gets the treasury address for an IP asset
     function ipTreasury(address ipaId) external view returns (address);
 

--- a/src/interfaces/IIPWorld.sol
+++ b/src/interfaces/IIPWorld.sol
@@ -2,10 +2,14 @@
 pragma solidity ^0.8.26;
 
 interface IIPWorld {
-    /// @notice Emitted when operator status is changed for an address
-    /// @param operator Address whose operator status changed
-    /// @param status True if operator status granted, false if revoked
-    event SetOperator(address indexed operator, bool status);
+    /// @notice Operator role types for access control separation
+    /// @dev None=0 (no access), Protocol=1 (core operations), Airdrop=2 (airdrop distribution)
+    enum OperatorType { None, Protocol, Airdrop }
+
+    /// @notice Emitted when operator type is changed for an address
+    /// @param operator Address whose operator type changed
+    /// @param operatorType The new operator type assigned
+    event SetOperator(address indexed operator, OperatorType operatorType);
 
     /// @notice Emitted when a new IP token is deployed
     /// @param tokenCreator Address of the token creator
@@ -164,10 +168,10 @@ interface IIPWorld {
     /// @return Percentage share of fees allocated to referrals (out of PRECISION)
     function referralShare() external view returns (uint24);
 
-    /// @notice Checks if an address is an operator
+    /// @notice Gets the operator type for an address
     /// @param operator Address to check
-    /// @return True if the address is an operator, false otherwise
-    function isOperator(address operator) external view returns (bool);
+    /// @return The operator type assigned to the address
+    function isOperator(address operator) external view returns (OperatorType);
 
     /// @notice Gets token information for a deployed IP world token
     /// @param token Address of the token
@@ -190,11 +194,11 @@ interface IIPWorld {
     /// @return Address of the pending recipient or zero if none exists
     function ipaPendingRecipient(address ipaId) external view returns (address);
 
-    /// @notice Sets or removes operator status for an address
+    /// @notice Sets the operator type for an address
     /// @dev Only the contract owner can call this function
-    /// @param operator Address to set operator status for
-    /// @param status True to grant operator permissions, false to revoke
-    function setOperator(address operator, bool status) external;
+    /// @param operator Address to set operator type for
+    /// @param operatorType The operator type to assign (None to revoke, Protocol or Airdrop to grant)
+    function setOperator(address operator, OperatorType operatorType) external;
 
     /// @notice Claims an IP asset for a recipient, initiating a two-step process if already claimed
     /// @dev Only operators can call this function. If the IP asset has no recipient, sets directly.

--- a/src/interfaces/IIPWorld.sol
+++ b/src/interfaces/IIPWorld.sol
@@ -4,7 +4,11 @@ pragma solidity ^0.8.26;
 interface IIPWorld {
     /// @notice Operator role types for access control separation
     /// @dev None=0 (no access), Protocol=1 (core operations), Airdrop=2 (airdrop distribution)
-    enum OperatorType { None, Protocol, Airdrop }
+    enum OperatorType {
+        None,
+        Protocol,
+        Airdrop
+    }
 
     /// @notice Emitted when operator type is changed for an address
     /// @param operator Address whose operator type changed
@@ -75,12 +79,7 @@ interface IIPWorld {
     event RecipientPending(address indexed ipaId, address indexed currentRecipient, address indexed pendingRecipient);
 
     /// @notice Emitted when referral fee is paid during harvest
-    event ReferralFeePaid(
-        address indexed token,
-        address indexed ipaId,
-        address indexed referrer,
-        uint256 amount
-    );
+    event ReferralFeePaid(address indexed token, address indexed ipaId, address indexed referrer, uint256 amount);
 
     /// @notice Emitted when fees are harvested with detailed distribution
     event HarvestDistributed(
@@ -110,7 +109,9 @@ interface IIPWorld {
     event AirdropClaimedUgc(address indexed token, address indexed recipient, uint256 tokenAmount, uint256 wethAmount);
 
     /// @notice Emitted when Holder airdrop is claimed by a recipient
-    event AirdropClaimedHolder(address indexed token, address indexed recipient, uint256 tokenAmount, uint256 wethAmount);
+    event AirdropClaimedHolder(
+        address indexed token, address indexed recipient, uint256 tokenAmount, uint256 wethAmount
+    );
 
     /// @notice Precision used for v3 calculations
     /// @return Precision constant used for percentage calculations

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -101,7 +101,8 @@ contract BaseTest is Test {
                             100_000,
                             500 ether,
                             Constants.CREATION_FEE,
-                            Constants.REFERRAL_SHARE
+                            Constants.REFERRAL_SHARE,
+                            400_000
                         )
                     ),
                     abi.encodeWithSelector(IPWorld.initialize.selector, address(this))

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -147,7 +147,7 @@ contract BaseTest is Test {
         spgNft.grantRole(SPGNFTLib.ADMIN_ROLE, address(ipWorld));
 
         // Now BaseTest is the owner, so we can call setOperator directly
-        ipWorld.setOperator(address(operator), true);
+        ipWorld.setOperator(address(operator), IIPWorld.OperatorType.Protocol);
 
         // for deposits
         vm.deal(address(alice), 100 ether);

--- a/test/integration/IPWorldRoyaltyPolicy.t.sol
+++ b/test/integration/IPWorldRoyaltyPolicy.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.26;
 import "forge-std/Test.sol";
 import {IPWorldRoyaltyPolicy} from "../../src/IPWorldRoyaltyPolicy.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import {RoyaltyModule} from "@storyprotocol/core/modules/royalty/RoyaltyModule.sol";
+import {IRoyaltyModule} from "@storyprotocol/core/interfaces/modules/royalty/IRoyaltyModule.sol";
 import {ILicensingModule} from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import {IPILicenseTemplate, PILTerms} from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 import {IIPAssetRegistry} from "@storyprotocol/core/interfaces/registries/IIPAssetRegistry.sol";
@@ -74,7 +74,7 @@ contract IPWorldRoyaltyPolicyTest is Test {
         IPWorldRoyaltyPolicy policy = IPWorldRoyaltyPolicy(address(proxy));
 
         // 2. Register as external royalty policy on RoyaltyModule
-        RoyaltyModule(Constants.ROYALTY_MODULE).registerExternalRoyaltyPolicy(address(policy));
+        IRoyaltyModule(Constants.ROYALTY_MODULE).registerExternalRoyaltyPolicy(address(policy));
 
         // 3. Register PIL terms with commercialUse=true and royaltyPolicy=policy
         PILTerms memory pilTerms = PILTerms({
@@ -137,7 +137,7 @@ contract IPWorldRoyaltyPolicyTest is Test {
 
         // Assert that the policy address is nonzero and registered
         assertTrue(address(policy) != address(0));
-        assertTrue(RoyaltyModule(Constants.ROYALTY_MODULE).isRegisteredExternalRoyaltyPolicy(address(policy)));
+        assertTrue(IRoyaltyModule(Constants.ROYALTY_MODULE).isRegisteredExternalRoyaltyPolicy(address(policy)));
 
         // Assert that PIL terms were registered successfully
         assertTrue(pilTermsId > 0);

--- a/test/integration/IPWorldRoyaltyPolicy.t.sol
+++ b/test/integration/IPWorldRoyaltyPolicy.t.sol
@@ -68,8 +68,9 @@ contract IPWorldRoyaltyPolicyTest is Test {
 
         // 1. Deploy upgradeable IPWorldRoyaltyPolicy
         IPWorldRoyaltyPolicy logic = new IPWorldRoyaltyPolicy();
-        ERC1967Proxy proxy =
-            new ERC1967Proxy(address(logic), abi.encodeWithSelector(IPWorldRoyaltyPolicy.initialize.selector));
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(logic), abi.encodeWithSelector(IPWorldRoyaltyPolicy.initialize.selector, testUser)
+        );
         vm.makePersistent(address(proxy));
         IPWorldRoyaltyPolicy policy = IPWorldRoyaltyPolicy(address(proxy));
 

--- a/test/integration/OldIPAsset.t.sol
+++ b/test/integration/OldIPAsset.t.sol
@@ -168,8 +168,8 @@ contract OldIPAssetTest is BaseTest {
         assertEq(linkedIpaId, OLD_IPA, "Token should be linked to old IPA");
     }
 
-    function test_OldIPAsset_LinkToken() public {
-        // Create a mock token to link
+    function test_OldIPAsset_LinkToken_RevertsForUnregisteredToken() public {
+        // Unregistered token should revert
         address[] memory tokens = new address[](1);
         tokens[0] = makeAddr("mockToken");
 
@@ -191,12 +191,8 @@ contract OldIPAssetTest is BaseTest {
         Operator.Signature memory sig = Operator.Signature(v, r, s);
 
         vm.prank(alice);
-        // This should succeed since operator can link tokens to IP
+        vm.expectRevert(Errors.IPWorld_WrongToken.selector);
         operator.linkTokenToIpWithSig(OLD_IPA, tokens, block.timestamp + 1000, sig);
-
-        // Verify the token was linked by checking token info
-        (address linkedIpaId,) = ipWorld.tokenInfo(tokens[0]);
-        assertEq(linkedIpaId, OLD_IPA, "Token should be linked to old IPA");
     }
 
     function test_OldIPAsset_ClaimDirect() public {
@@ -366,10 +362,8 @@ contract OldIPAssetTest is BaseTest {
     function test_OldIPAsset_ClaimIp_ValidCall() public {
         address claimer = bob;
 
-        // Create token addresses array
-        address[] memory tokens = new address[](2);
-        tokens[0] = makeAddr("token1");
-        tokens[1] = makeAddr("token2");
+        // Use empty token array since linkTokensToIp validates token registration
+        address[] memory tokens = new address[](0);
 
         address referral = makeAddr("referral1");
 
@@ -453,10 +447,6 @@ contract OldIPAssetTest is BaseTest {
         operator.claimIpWithSig(
             testIpAsset, claimer, tokens, referral, address(0), block.timestamp + 1000, sig, ipOwnerSig
         );
-
-        // Verify the tokens are linked to the IP
-        (address linkedIpaId,) = ipWorld.tokenInfo(tokens[0]);
-        assertEq(linkedIpaId, testIpAsset, "Token should be linked to test IP asset");
 
         // Verify the claim was successful
         address recipient = ipWorld.ipaRecipient(testIpAsset);

--- a/test/integration/OldIPAsset.t.sol
+++ b/test/integration/OldIPAsset.t.sol
@@ -173,14 +173,11 @@ contract OldIPAssetTest is BaseTest {
         address[] memory tokens = new address[](1);
         tokens[0] = makeAddr("mockToken");
 
-
         bytes32 digest = MessageHashUtils.toTypedDataHash(
             operator.DOMAIN_SEPARATOR(),
             keccak256(
                 abi.encode(
-                    keccak256(
-                        "LINK(address sender,address ipaId,address[] tokens,uint256 nonce,uint256 deadline)"
-                    ),
+                    keccak256("LINK(address sender,address ipaId,address[] tokens,uint256 nonce,uint256 deadline)"),
                     alice,
                     OLD_IPA,
                     keccak256(abi.encodePacked(tokens)),
@@ -453,7 +450,9 @@ contract OldIPAssetTest is BaseTest {
 
         // Call from alice (not the IP owner), using both signatures
         vm.prank(alice);
-        operator.claimIpWithSig(testIpAsset, claimer, tokens, referral, address(0), block.timestamp + 1000, sig, ipOwnerSig);
+        operator.claimIpWithSig(
+            testIpAsset, claimer, tokens, referral, address(0), block.timestamp + 1000, sig, ipOwnerSig
+        );
 
         // Verify the tokens are linked to the IP
         (address linkedIpaId,) = ipWorld.tokenInfo(tokens[0]);
@@ -500,7 +499,9 @@ contract OldIPAssetTest is BaseTest {
 
         vm.prank(alice);
         vm.expectRevert(abi.encodeWithSelector(Errors.Operator_InvalidAddress.selector));
-        operator.claimIpWithSig(OLD_IPA, claimer, tokens, referral, address(0), block.timestamp + 1000, sig, dummyIpOwnerSig);
+        operator.claimIpWithSig(
+            OLD_IPA, claimer, tokens, referral, address(0), block.timestamp + 1000, sig, dummyIpOwnerSig
+        );
     }
 
     function test_OldIPAsset_ClaimIp_InvalidIpaId() public {
@@ -540,7 +541,9 @@ contract OldIPAssetTest is BaseTest {
 
         vm.prank(alice);
         vm.expectRevert(abi.encodeWithSelector(Errors.Operator_InvalidAddress.selector));
-        operator.claimIpWithSig(ipaId, claimer, tokens, referral, address(0), block.timestamp + 1000, sig, dummyIpOwnerSig);
+        operator.claimIpWithSig(
+            ipaId, claimer, tokens, referral, address(0), block.timestamp + 1000, sig, dummyIpOwnerSig
+        );
     }
 
     function test_OldIPAsset_ClaimIp_EmptyTokens() public {
@@ -580,6 +583,8 @@ contract OldIPAssetTest is BaseTest {
         // This should still work, just claiming IP without linking tokens
         vm.prank(alice);
         vm.expectRevert(); // Expecting revert from Story Protocol integration
-        operator.claimIpWithSig(OLD_IPA, claimer, tokens, referral, address(0), block.timestamp + 1000, sig, emptyIpOwnerSig);
+        operator.claimIpWithSig(
+            OLD_IPA, claimer, tokens, referral, address(0), block.timestamp + 1000, sig, emptyIpOwnerSig
+        );
     }
 }

--- a/test/unit/IPWorld.t.sol
+++ b/test/unit/IPWorld.t.sol
@@ -554,6 +554,6 @@ contract IPWorldTest is BaseTest {
 
     function test_IPWorld_setOperator_treasury_reverts() public {
         vm.expectRevert(Errors.IPWorld_InvalidAddress.selector);
-        ipWorld.setOperator(treasury, true);
+        ipWorld.setOperator(treasury, IIPWorld.OperatorType.Protocol);
     }
 }

--- a/test/unit/IPWorldRoyaltyPolicy.t.sol
+++ b/test/unit/IPWorldRoyaltyPolicy.t.sol
@@ -13,8 +13,9 @@ contract IPWorldRoyaltyPolicyTest is Test {
         // Deploy logic contract
         IPWorldRoyaltyPolicy logic = new IPWorldRoyaltyPolicy();
         // Deploy proxy
-        ERC1967Proxy proxy =
-            new ERC1967Proxy(address(logic), abi.encodeWithSelector(IPWorldRoyaltyPolicy.initialize.selector));
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(logic), abi.encodeWithSelector(IPWorldRoyaltyPolicy.initialize.selector, address(this))
+        );
         // Wrap as policy
         policy = IPWorldRoyaltyPolicy(address(proxy));
     }

--- a/test/unit/OperatorEnum.t.sol
+++ b/test/unit/OperatorEnum.t.sol
@@ -52,7 +52,8 @@ contract OperatorEnumTest is Test {
                             100_000,
                             500 ether,
                             Constants.CREATION_FEE,
-                            Constants.REFERRAL_SHARE
+                            Constants.REFERRAL_SHARE,
+                            400_000
                         )
                     ),
                     abi.encodeWithSelector(IPWorld.initialize.selector, address(this))

--- a/test/unit/OperatorEnum.t.sol
+++ b/test/unit/OperatorEnum.t.sol
@@ -125,14 +125,12 @@ contract OperatorEnumTest is Test {
         ipWorld.setReferral(ipaId, referral_);
     }
 
-    function test_protocolOp_canCallLinkTokensToIp() public {
+    function test_protocolOp_canCallLinkTokensToIp_revertsForUnregisteredToken() public {
         address ipaId = makeAddr("ipa4");
         address[] memory tokens = new address[](1);
         tokens[0] = makeAddr("token1");
         vm.prank(protocolOp);
-        // This will not fully succeed since token1 is not a real token with info,
-        // but it should pass the onlyOperator check
-        vm.expectRevert(); // Expected revert from token info, not from operator check
+        vm.expectRevert(Errors.IPWorld_WrongToken.selector);
         ipWorld.linkTokensToIp(ipaId, tokens);
     }
 

--- a/test/unit/OperatorEnum.t.sol
+++ b/test/unit/OperatorEnum.t.sol
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {IPWorld} from "../../src/IPWorld.sol";
+import {IPOwnerVault} from "../../src/IPOwnerVault.sol";
+import {IPTokenDeployer} from "../../src/IPTokenDeployer.sol";
+import {IIPWorld} from "../../src/interfaces/IIPWorld.sol";
+import {IWETH9} from "../../src/interfaces/IWETH9.sol";
+import {Errors} from "../../src/lib/Errors.sol";
+import {Constants} from "../../utils/Constants.sol";
+
+/// @title OperatorEnum Test
+/// @notice Tests for OperatorType enum-based role separation
+contract OperatorEnumTest is Test {
+    IIPWorld internal ipWorld;
+    address internal treasury = Constants.TREASURY;
+
+    address internal protocolOp = makeAddr("protocolOperator");
+    address internal airdropOp = makeAddr("airdropOperator");
+    address internal nobody = makeAddr("nobody");
+
+    function setUp() public {
+        vm.createSelectFork(Constants.STORY_MAINNET_RPC);
+
+        address expectedIpWorldAddress = vm.computeCreateAddress(address(this), vm.getNonce(address(this)) + 4);
+        address ownerVaultAddr = address(
+            new ERC1967Proxy(
+                address(new IPOwnerVault(expectedIpWorldAddress, Constants.VESTING_DURATION)),
+                abi.encodeWithSelector(IPOwnerVault.initialize.selector, address(this))
+            )
+        );
+
+        IPTokenDeployer tokenDeployer = new IPTokenDeployer(expectedIpWorldAddress);
+
+        ipWorld = IIPWorld(
+            address(
+                new ERC1967Proxy(
+                    address(
+                        new IPWorld(
+                            Constants.WETH,
+                            Constants.V3_DEPLOYER,
+                            Constants.V3_FACTORY,
+                            address(tokenDeployer),
+                            ownerVaultAddr,
+                            treasury,
+                            300_000,
+                            200_000,
+                            100_000,
+                            500 ether,
+                            Constants.CREATION_FEE,
+                            Constants.REFERRAL_SHARE
+                        )
+                    ),
+                    abi.encodeWithSelector(IPWorld.initialize.selector, address(this))
+                )
+            )
+        );
+
+        assertEq(address(ipWorld), expectedIpWorldAddress, "IPWorld address mismatch");
+
+        // Set owner via storage slot (same as BaseTest)
+        bytes32 ownableStorageSlot = 0x9016d09d72d40fdae2fd8ceac6b6234c7706214fd39c1cd1e609a0528c199300;
+        vm.store(address(ipWorld), ownableStorageSlot, bytes32(uint256(uint160(address(this)))));
+
+        // Set up operators with different roles
+        ipWorld.setOperator(protocolOp, IIPWorld.OperatorType.Protocol);
+        ipWorld.setOperator(airdropOp, IIPWorld.OperatorType.Airdrop);
+    }
+
+    // --- setOperator tests ---
+
+    function test_setOperator_Protocol() public view {
+        assertEq(uint8(ipWorld.isOperator(protocolOp)), uint8(IIPWorld.OperatorType.Protocol));
+    }
+
+    function test_setOperator_Airdrop() public view {
+        assertEq(uint8(ipWorld.isOperator(airdropOp)), uint8(IIPWorld.OperatorType.Airdrop));
+    }
+
+    function test_setOperator_None_revokes() public {
+        ipWorld.setOperator(protocolOp, IIPWorld.OperatorType.None);
+        assertEq(uint8(ipWorld.isOperator(protocolOp)), uint8(IIPWorld.OperatorType.None));
+    }
+
+    function test_setOperator_treasury_reverts() public {
+        vm.expectRevert(Errors.IPWorld_InvalidAddress.selector);
+        ipWorld.setOperator(treasury, IIPWorld.OperatorType.Protocol);
+    }
+
+    function test_setOperator_emitsEvent() public {
+        vm.expectEmit(true, false, false, true, address(ipWorld));
+        emit IIPWorld.SetOperator(protocolOp, IIPWorld.OperatorType.Airdrop);
+        ipWorld.setOperator(protocolOp, IIPWorld.OperatorType.Airdrop);
+    }
+
+    function test_unassignedAddress_isNone() public view {
+        assertEq(uint8(ipWorld.isOperator(nobody)), uint8(IIPWorld.OperatorType.None));
+    }
+
+    // --- Protocol operator access tests ---
+
+    function test_protocolOp_canCallClaimIp() public {
+        address ipaId = makeAddr("ipa1");
+        address recipient = makeAddr("recipient1");
+        vm.prank(protocolOp);
+        ipWorld.claimIp(ipaId, recipient, address(0));
+    }
+
+    function test_protocolOp_canCallSetIpTreasury() public {
+        address ipaId = makeAddr("ipa2");
+        address ipTreasury_ = makeAddr("ipTreasury");
+        vm.prank(protocolOp);
+        ipWorld.setIpTreasury(ipaId, ipTreasury_);
+    }
+
+    function test_protocolOp_canCallSetReferral() public {
+        address ipaId = makeAddr("ipa3");
+        address referral_ = makeAddr("referral");
+        vm.prank(protocolOp);
+        ipWorld.setReferral(ipaId, referral_);
+    }
+
+    function test_protocolOp_canCallLinkTokensToIp() public {
+        address ipaId = makeAddr("ipa4");
+        address[] memory tokens = new address[](1);
+        tokens[0] = makeAddr("token1");
+        vm.prank(protocolOp);
+        // This will not fully succeed since token1 is not a real token with info,
+        // but it should pass the onlyOperator check
+        vm.expectRevert(); // Expected revert from token info, not from operator check
+        ipWorld.linkTokensToIp(ipaId, tokens);
+    }
+
+    // --- Airdrop operator CANNOT call Protocol functions ---
+
+    function test_airdropOp_cannotCallClaimIp() public {
+        address ipaId = makeAddr("ipa5");
+        address recipient = makeAddr("recipient2");
+        vm.prank(airdropOp);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.claimIp(ipaId, recipient, address(0));
+    }
+
+    function test_airdropOp_cannotCallSetIpTreasury() public {
+        address ipaId = makeAddr("ipa6");
+        address ipTreasury_ = makeAddr("ipTreasury2");
+        vm.prank(airdropOp);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.setIpTreasury(ipaId, ipTreasury_);
+    }
+
+    function test_airdropOp_cannotCallSetReferral() public {
+        address ipaId = makeAddr("ipa7");
+        address referral_ = makeAddr("referral2");
+        vm.prank(airdropOp);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.setReferral(ipaId, referral_);
+    }
+
+    function test_airdropOp_cannotCallLinkTokensToIp() public {
+        address ipaId = makeAddr("ipa8");
+        address[] memory tokens = new address[](1);
+        tokens[0] = makeAddr("token2");
+        vm.prank(airdropOp);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.linkTokensToIp(ipaId, tokens);
+    }
+
+    // --- Protocol operator CANNOT call Airdrop functions ---
+
+    function test_protocolOp_cannotCallClaimAirdropUgc() public {
+        address token = makeAddr("token3");
+        address[] memory recipients = new address[](0);
+        uint256[] memory tokenAmounts = new uint256[](0);
+        uint256[] memory wethAmounts = new uint256[](0);
+        vm.prank(protocolOp);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.claimAirdropUgc(token, recipients, tokenAmounts, wethAmounts);
+    }
+
+    function test_protocolOp_cannotCallClaimAirdropHolder() public {
+        address token = makeAddr("token4");
+        address[] memory recipients = new address[](0);
+        uint256[] memory tokenAmounts = new uint256[](0);
+        uint256[] memory wethAmounts = new uint256[](0);
+        vm.prank(protocolOp);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.claimAirdropHolder(token, recipients, tokenAmounts, wethAmounts);
+    }
+
+    // --- Nobody (None) CANNOT call anything ---
+
+    function test_nobody_cannotCallClaimIp() public {
+        address ipaId = makeAddr("ipa9");
+        address recipient = makeAddr("recipient3");
+        vm.prank(nobody);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.claimIp(ipaId, recipient, address(0));
+    }
+
+    function test_nobody_cannotCallClaimAirdropUgc() public {
+        address token = makeAddr("token5");
+        address[] memory recipients = new address[](0);
+        uint256[] memory tokenAmounts = new uint256[](0);
+        uint256[] memory wethAmounts = new uint256[](0);
+        vm.prank(nobody);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.claimAirdropUgc(token, recipients, tokenAmounts, wethAmounts);
+    }
+
+    function test_nobody_cannotCallClaimAirdropHolder() public {
+        address token = makeAddr("token6");
+        address[] memory recipients = new address[](0);
+        uint256[] memory tokenAmounts = new uint256[](0);
+        uint256[] memory wethAmounts = new uint256[](0);
+        vm.prank(nobody);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.claimAirdropHolder(token, recipients, tokenAmounts, wethAmounts);
+    }
+
+    // --- Revocation tests ---
+
+    function test_revokeOperator_protocolCannotCallAnymore() public {
+        // Revoke protocol operator
+        ipWorld.setOperator(protocolOp, IIPWorld.OperatorType.None);
+
+        address ipaId = makeAddr("ipa10");
+        address recipient = makeAddr("recipient4");
+        vm.prank(protocolOp);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.claimIp(ipaId, recipient, address(0));
+    }
+
+    function test_revokeOperator_airdropCannotCallAnymore() public {
+        // Revoke airdrop operator
+        ipWorld.setOperator(airdropOp, IIPWorld.OperatorType.None);
+
+        address token = makeAddr("token7");
+        address[] memory recipients = new address[](0);
+        uint256[] memory tokenAmounts = new uint256[](0);
+        uint256[] memory wethAmounts = new uint256[](0);
+        vm.prank(airdropOp);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.claimAirdropUgc(token, recipients, tokenAmounts, wethAmounts);
+    }
+
+    // --- Role change tests ---
+
+    function test_changeRole_protocolToAirdrop() public {
+        // Change protocol operator to airdrop
+        ipWorld.setOperator(protocolOp, IIPWorld.OperatorType.Airdrop);
+        assertEq(uint8(ipWorld.isOperator(protocolOp)), uint8(IIPWorld.OperatorType.Airdrop));
+
+        // Should not be able to call protocol functions
+        address ipaId = makeAddr("ipa11");
+        vm.prank(protocolOp);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.claimIp(ipaId, makeAddr("rec"), address(0));
+    }
+
+    function test_changeRole_airdropToProtocol() public {
+        // Change airdrop operator to protocol
+        ipWorld.setOperator(airdropOp, IIPWorld.OperatorType.Protocol);
+        assertEq(uint8(ipWorld.isOperator(airdropOp)), uint8(IIPWorld.OperatorType.Protocol));
+
+        // Should be able to call protocol functions
+        address ipaId = makeAddr("ipa12");
+        vm.prank(airdropOp);
+        ipWorld.claimIp(ipaId, makeAddr("rec2"), address(0));
+
+        // Should not be able to call airdrop functions
+        address token = makeAddr("token8");
+        address[] memory recipients = new address[](0);
+        uint256[] memory tokenAmounts = new uint256[](0);
+        uint256[] memory wethAmounts = new uint256[](0);
+        vm.prank(airdropOp);
+        vm.expectRevert(Errors.IPWorld_OperatorOnly.selector);
+        ipWorld.claimAirdropUgc(token, recipients, tokenAmounts, wethAmounts);
+    }
+}

--- a/test/upgradeable/UUPSUpgradeable.t.sol
+++ b/test/upgradeable/UUPSUpgradeable.t.sol
@@ -30,7 +30,8 @@ contract UUPSUpgradeableTest is Test {
                 100_000,
                 500 ether,
                 0.01 ether,
-                50_000
+                50_000,
+                400_000
             )
         );
         address owner = address(0x08);

--- a/utils/Constants.sol
+++ b/utils/Constants.sol
@@ -82,10 +82,11 @@ library Constants {
         0x527b390cD37643F10dA8B8Dca980FA46EEe2f58b;
 
     // IPWorld deployment parameters
-    uint24 public constant AIRDROP_SHARE = 125_000;
-    uint24 public constant IP_OWNER_SHARE = 125_000;
+    uint24 public constant AIRDROP_SHARE = 100_000;
+    uint24 public constant IP_OWNER_SHARE = 100_000;
     uint24 public constant BUYBACK_SHARE = 250_000;
     uint24 public constant REFERRAL_SHARE = 25_000;
+    uint24 public constant TOKEN_AIRDROP_SHARE = 400_000;
     uint256 public constant BID_WALL_AMOUNT = 20 ether;
     uint64 public constant VESTING_DURATION = 180 days;
     uint256 public constant CREATION_FEE = 10 ether;


### PR DESCRIPTION
## Summary
- Add independent `tokenAirdropShare` constructor parameter so token and ETH airdrop distributions can be configured separately
- Token airdrop calculation now uses `tokenAirdropShare` (400k / 40%) instead of reusing `airdropShare`
- Adjust fee shares: AIRDROP_SHARE 125k→100k, IP_OWNER_SHARE 125k→100k

## Test plan
- [x] BaseTest, OperatorEnum, UUPSUpgradeable tests updated with new constructor parameter
- [ ] Verify fee distribution calculations in integration tests