### PR TITLE
Apply forge fmt formatting

### DIFF
--- a/src/Operator.sol
+++ b/src/Operator.sol
@@ -15,8 +15,9 @@ import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Po
 import {WorkflowStructs} from "@storyprotocol/periphery/lib/WorkflowStructs.sol";
 import {IRegistrationWorkflows} from "@storyprotocol/periphery/interfaces/workflows/IRegistrationWorkflows.sol";
 import {ILicensingModuleWithNFT} from "./interfaces/ILicensingModuleWithNFT.sol";
-import {ILicenseAttachmentWorkflows} from
-    "@storyprotocol/periphery/interfaces/workflows/ILicenseAttachmentWorkflows.sol";
+import {
+    ILicenseAttachmentWorkflows
+} from "@storyprotocol/periphery/interfaces/workflows/ILicenseAttachmentWorkflows.sol";
 import {Licensing} from "@storyprotocol/core/lib/Licensing.sol";
 import {ISPGNFT} from "@storyprotocol/periphery/interfaces/ISPGNFT.sol";
 
@@ -55,8 +56,9 @@ contract Operator is IStoryHuntV3SwapCallback, EIP712, Nonces, Ownable2Step, IER
         keccak256("LINK(address sender,address ipaId,address[] tokens,uint256 nonce,uint256 deadline)");
 
     /// @notice Authorizes claiming IP assets with token linking
-    bytes32 internal constant CLAIM_IP_TYPEHASH =
-        keccak256("CLAIM(address sender,address ipaId,address claimer,address[] tokens,uint256 nonce,uint256 deadline)");
+    bytes32 internal constant CLAIM_IP_TYPEHASH = keccak256(
+        "CLAIM(address sender,address ipaId,address claimer,address[] tokens,uint256 nonce,uint256 deadline)"
+    );
 
     /// @notice Fee value for LP pools (this is equivalent to a 0.3% fee)
     uint24 public constant V3_FEE = 3000;
@@ -172,13 +174,14 @@ contract Operator is IStoryHuntV3SwapCallback, EIP712, Nonces, Ownable2Step, IER
 
         if (msg.value > 0) {
             // @dev msg.value can't be greater than type(int256).max
-            IUniswapV3Pool(pool).swap(
-                msg.sender,
-                !(token < _weth),
-                int256(msg.value),
-                token < _weth ? TickMath.MAX_SQRT_RATIO - 1 : TickMath.MIN_SQRT_RATIO + 1,
-                abi.encode(token)
-            );
+            IUniswapV3Pool(pool)
+                .swap(
+                    msg.sender,
+                    !(token < _weth),
+                    int256(msg.value),
+                    token < _weth ? TickMath.MAX_SQRT_RATIO - 1 : TickMath.MIN_SQRT_RATIO + 1,
+                    abi.encode(token)
+                );
         }
         _transferETH(msg.sender, address(this).balance);
     }
@@ -249,20 +252,21 @@ contract Operator is IStoryHuntV3SwapCallback, EIP712, Nonces, Ownable2Step, IER
 
         //Mint, register the IPA, attach custom PIL Terms and transfer IPA to Operator
         (address ipaId, uint256 tokenId, uint256[] memory licenseTermsIds) = ILicenseAttachmentWorkflows(
-            Constants.LICENSE_ATTACHMENT_WORKFLOWS
-        ).mintAndRegisterIpAndAttachPILTerms(spgNft, address(this), ipMetadata, licenseTermsData, false);
+                Constants.LICENSE_ATTACHMENT_WORKFLOWS
+            ).mintAndRegisterIpAndAttachPILTerms(spgNft, address(this), ipMetadata, licenseTermsData, false);
 
         //Mint 1 License Token and transfer it to Operator
-        ILicensingModuleWithNFT(Constants.LICENSING_MODULE).mintLicenseTokens(
-            ipaId,
-            Constants.PILICENSE_TEMPLATE,
-            licenseTermsIds[0],
-            1,
-            address(this),
-            "",
-            type(uint256).max,
-            type(uint32).max
-        );
+        ILicensingModuleWithNFT(Constants.LICENSING_MODULE)
+            .mintLicenseTokens(
+                ipaId,
+                Constants.PILICENSE_TEMPLATE,
+                licenseTermsIds[0],
+                1,
+                address(this),
+                "",
+                type(uint256).max,
+                type(uint32).max
+            );
 
         ipWorld.linkTokensToIp(ipaId, tokens);
         ipWorld.claimIp(ipaId, claimer);
@@ -393,14 +397,15 @@ contract Operator is IStoryHuntV3SwapCallback, EIP712, Nonces, Ownable2Step, IER
         });
 
         // Set permissions using executeWithSig
-        IIPAccount(payable(ipaId)).executeWithSig(
-            Constants.ACCESS_CONTROLLER,
-            0,
-            abi.encodeWithSelector(IAccessController.setBatchTransientPermissions.selector, permissionList),
-            sigAttachAndConfig.signer,
-            sigAttachAndConfig.deadline,
-            sigAttachAndConfig.signature
-        );
+        IIPAccount(payable(ipaId))
+            .executeWithSig(
+                Constants.ACCESS_CONTROLLER,
+                0,
+                abi.encodeWithSelector(IAccessController.setBatchTransientPermissions.selector, permissionList),
+                sigAttachAndConfig.signer,
+                sigAttachAndConfig.deadline,
+                sigAttachAndConfig.signature
+            );
 
         // Step 2: Register, attach, and set configs directly (LicensingHelper internal logic)
 
@@ -411,8 +416,9 @@ contract Operator is IStoryHuntV3SwapCallback, EIP712, Nonces, Ownable2Step, IER
         // Attach license terms
         ILicensingModule licensingModule = ILicensingModule(Constants.LICENSING_MODULE);
         try licensingModule.attachLicenseTerms(ipaId, Constants.PILICENSE_TEMPLATE, licenseTermsId) {
-            // license terms are attached successfully
-        } catch (bytes memory reason) {
+        // license terms are attached successfully
+        }
+        catch (bytes memory reason) {
             // if the error is not that the license terms are already attached, revert with the original error
             if (bytes4(reason) != 0x650aa092) {
                 // LicenseRegistry__LicenseTermsAlreadyAttached selector
@@ -434,16 +440,17 @@ contract Operator is IStoryHuntV3SwapCallback, EIP712, Nonces, Ownable2Step, IER
 
         // Mint 1 License Token using the newly attached license terms
 
-        ILicensingModuleWithNFT(Constants.LICENSING_MODULE).mintLicenseTokens(
-            ipaId,
-            Constants.PILICENSE_TEMPLATE,
-            licenseTermsIds[0], // Use the newly created license terms ID
-            1,
-            address(this),
-            "",
-            type(uint256).max,
-            type(uint32).max
-        );
+        ILicensingModuleWithNFT(Constants.LICENSING_MODULE)
+            .mintLicenseTokens(
+                ipaId,
+                Constants.PILICENSE_TEMPLATE,
+                licenseTermsIds[0], // Use the newly created license terms ID
+                1,
+                address(this),
+                "",
+                type(uint256).max,
+                type(uint32).max
+            );
 
         // Link tokens to IP and claim
         ipWorld.linkTokensToIp(ipaId, tokens);

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -67,8 +67,9 @@ contract BaseTest is Test {
         vm.createSelectFork(Constants.STORY_MAINNET_RPC);
         address owner = address(this);
 
-        ipMetadataEmpty =
-            WorkflowStructs.IPMetadata({ipMetadataURI: "", ipMetadataHash: "", nftMetadataURI: "", nftMetadataHash: ""});
+        ipMetadataEmpty = WorkflowStructs.IPMetadata({
+            ipMetadataURI: "", ipMetadataHash: "", nftMetadataURI: "", nftMetadataHash: ""
+        });
 
         address expectedIpWorldAddress = vm.computeCreateAddress(address(this), vm.getNonce(address(this)) + 4);
 

--- a/test/integration/IPWorldRoyaltyPolicy.t.sol
+++ b/test/integration/IPWorldRoyaltyPolicy.t.sol
@@ -103,21 +103,21 @@ contract IPWorldRoyaltyPolicyTest is Test {
         address parentIpId = IIPAssetRegistry(Constants.IP_ASSET_REGISTRY).register(block.chainid, address(mockNFT), 1);
 
         // 5. Attach PIL terms to parent IP
-        ILicensingModule(Constants.LICENSING_MODULE).attachLicenseTerms(
-            parentIpId, Constants.PILICENSE_TEMPLATE, pilTermsId
-        );
+        ILicensingModule(Constants.LICENSING_MODULE)
+            .attachLicenseTerms(parentIpId, Constants.PILICENSE_TEMPLATE, pilTermsId);
 
         // 6. Mint license token for parent IP
-        uint256 licenseTokenId = ILicensingModule(Constants.LICENSING_MODULE).mintLicenseTokens(
-            parentIpId,
-            Constants.PILICENSE_TEMPLATE,
-            pilTermsId,
-            1, // amount
-            testUser, // receiver
-            "", // royaltyContext
-            0, // maxMintingFee
-            0 // maxRevenueShare
-        );
+        uint256 licenseTokenId = ILicensingModule(Constants.LICENSING_MODULE)
+            .mintLicenseTokens(
+                parentIpId,
+                Constants.PILICENSE_TEMPLATE,
+                pilTermsId,
+                1, // amount
+                testUser, // receiver
+                "", // royaltyContext
+                0, // maxMintingFee
+                0 // maxRevenueShare
+            );
 
         // 7. Register derivative IP using mockNFT
         address derivativeIpId =
@@ -127,12 +127,13 @@ contract IPWorldRoyaltyPolicyTest is Test {
         uint256[] memory licenseTokenIds = new uint256[](1);
         licenseTokenIds[0] = licenseTokenId;
 
-        ILicensingModule(Constants.LICENSING_MODULE).registerDerivativeWithLicenseTokens(
-            derivativeIpId,
-            licenseTokenIds,
-            "", // royaltyContext
-            0 // maxRts
-        );
+        ILicensingModule(Constants.LICENSING_MODULE)
+            .registerDerivativeWithLicenseTokens(
+                derivativeIpId,
+                licenseTokenIds,
+                "", // royaltyContext
+                0 // maxRts
+            );
 
         // Assert that the policy address is nonzero and registered
         assertTrue(address(policy) != address(0));

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -508,13 +508,11 @@ contract IntegrationTest is BaseTest {
     function getQuoteForExactOutput(IERC20Metadata token, uint256 amountOut) internal returns (uint256) {
         try quoterV2.quoteExactOutputSingle(
             IQuoterV2.QuoteExactOutputSingleParams({
-                tokenIn: address(weth),
-                tokenOut: address(token),
-                amount: amountOut,
-                fee: POOL_FEE,
-                sqrtPriceLimitX96: 0
+                tokenIn: address(weth), tokenOut: address(token), amount: amountOut, fee: POOL_FEE, sqrtPriceLimitX96: 0
             })
-        ) returns (uint256 quotedAmountIn, uint160, uint32, uint256) {
+        ) returns (
+            uint256 quotedAmountIn, uint160, uint32, uint256
+        ) {
             return quotedAmountIn;
         } catch {
             console2.log("Failed to get quote");
@@ -881,7 +879,9 @@ contract IntegrationTest is BaseTest {
                 fee: POOL_FEE,
                 sqrtPriceLimitX96: 0
             })
-        ) returns (uint256 quotedAmountIn, uint160, uint32, uint256) {
+        ) returns (
+            uint256 quotedAmountIn, uint160, uint32, uint256
+        ) {
             // Use actual total supply instead of hardcoded 1B
             uint256 quoterMarketCap = quotedAmountIn * totalSupply / (10 ** token.decimals());
             console2.log("Market Cap:", quoterMarketCap / 1e18, "WETH");
@@ -910,7 +910,9 @@ contract IntegrationTest is BaseTest {
                 fee: POOL_FEE,
                 sqrtPriceLimitX96: 0
             })
-        ) returns (uint256 quotedAmountIn, uint160, uint32, uint256) {
+        ) returns (
+            uint256 quotedAmountIn, uint160, uint32, uint256
+        ) {
             tokenPriceInWeth = quotedAmountIn;
         } catch {
             console2.log("Failed to get token price for liquidity calculation");
@@ -1177,7 +1179,9 @@ contract IntegrationTest is BaseTest {
                 fee: POOL_FEE,
                 sqrtPriceLimitX96: 0
             })
-        ) returns (uint256 quotedAmountIn, uint160, uint32, uint256) {
+        ) returns (
+            uint256 quotedAmountIn, uint160, uint32, uint256
+        ) {
             return quotedAmountIn * totalSupply / (10 ** token.decimals());
         } catch {
             return 0;
@@ -1197,7 +1201,9 @@ contract IntegrationTest is BaseTest {
                 fee: POOL_FEE,
                 sqrtPriceLimitX96: 0
             })
-        ) returns (uint256 tokenPriceInWeth, uint160, uint32, uint256) {
+        ) returns (
+            uint256 tokenPriceInWeth, uint160, uint32, uint256
+        ) {
             uint256 tokenValueInWeth = FullMath.mulDiv(tokenBalance, tokenPriceInWeth, 10 ** token.decimals());
             return tokenValueInWeth + wethBalance;
         } catch {
@@ -1227,10 +1233,7 @@ contract IntegrationTest is BaseTest {
         });
     }
 
-    function storyHuntV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata _data)
-        external
-        override
-    {
+    function storyHuntV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata _data) external override {
         require(amount0Delta > 0 || amount1Delta > 0); // swaps entirely within 0-liquidity regions are not supported
         SwapCallbackData memory data = abi.decode(_data, (SwapCallbackData));
         (address tokenIn, address tokenOut,) = data.path.decodeFirstPool();

--- a/test/integration/OldIPAsset.t.sol
+++ b/test/integration/OldIPAsset.t.sol
@@ -115,11 +115,7 @@ contract OldIPAssetTest is BaseTest {
             MetaTx.calculateDomainSeparator(ipId),
             MetaTx.getExecuteStructHash(
                 MetaTx.Execute({
-                    to: Constants.ACCESS_CONTROLLER,
-                    value: 0,
-                    data: data,
-                    nonce: expectedState,
-                    deadline: deadline
+                    to: Constants.ACCESS_CONTROLLER, value: 0, data: data, nonce: expectedState, deadline: deadline
                 })
             )
         );

--- a/test/upgradeable/UUPSUpgradeable.t.sol
+++ b/test/upgradeable/UUPSUpgradeable.t.sol
@@ -45,9 +45,8 @@ contract UUPSUpgradeableTest is Test {
 
         uint64 version = 3;
         vm.prank(address(0x08));
-        UUPSUpgradeable(address(ipWorld)).upgradeToAndCall(
-            template, abi.encodeWithSelector(XXXX.initialize.selector, address(this), version)
-        );
+        UUPSUpgradeable(address(ipWorld))
+            .upgradeToAndCall(template, abi.encodeWithSelector(XXXX.initialize.selector, address(this), version));
 
         assertEq(Ownable(address(ipWorld)).owner(), address(this));
     }


### PR DESCRIPTION
## Summary
- Apply `forge fmt` code formatting across contract and test files
- No logic changes, style-only

## Test plan
- [ ] Verify all tests pass after formatting changes